### PR TITLE
feat: 정책카드 UI 개선 및 필터/페이지 기능 강화

### DIFF
--- a/frontend/src/app/components/atoms/CustomSelect.tsx
+++ b/frontend/src/app/components/atoms/CustomSelect.tsx
@@ -1,0 +1,71 @@
+import { useState, useRef, useEffect } from 'react';
+import { ChevronDown, Check } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface CustomSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+  placeholder?: string;
+  className?: string;
+}
+
+export function CustomSelect({ value, onChange, options, placeholder = '선택하세요', className }: CustomSelectProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const selectedLabel = options.find((o) => o.value === value)?.label;
+
+  return (
+    <div ref={ref} className={cn('relative', className)}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          'w-full flex items-center justify-between gap-2 rounded-xl border px-4 py-2.5 text-sm font-medium bg-white transition-all duration-200',
+          open
+            ? 'border-[var(--accent)] text-[var(--foreground)] shadow-sm ring-2 ring-[var(--accent)]/20'
+            : 'border-[var(--border)] text-[var(--foreground)] hover:border-[var(--accent)]',
+          !selectedLabel && 'text-[var(--muted-foreground)]',
+        )}
+      >
+        <span>{selectedLabel ?? placeholder}</span>
+        <ChevronDown className={cn('h-4 w-4 text-[var(--muted-foreground)] transition-transform duration-200 flex-shrink-0', open && 'rotate-180')} />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 right-0 top-full mt-1.5 z-50 bg-white border border-[var(--border)] rounded-xl shadow-lg overflow-hidden">
+          {options.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => { onChange(opt.value); setOpen(false); }}
+              className={cn(
+                'w-full flex items-center justify-between px-4 py-2.5 text-sm transition-colors',
+                value === opt.value
+                  ? 'bg-[var(--accent)]/10 text-[var(--accent)] font-medium'
+                  : 'text-[var(--foreground)] hover:bg-[var(--muted)]',
+              )}
+            >
+              {opt.label}
+              {value === opt.value && <Check className="h-3.5 w-3.5 flex-shrink-0" />}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/components/molecules/PolicyMetaRow.tsx
+++ b/frontend/src/app/components/molecules/PolicyMetaRow.tsx
@@ -1,30 +1,32 @@
 import { Building2, MapPin, Calendar } from 'lucide-react';
+import { cn } from '../../lib/utils';
 
 export interface PolicyMetaRowProps {
   agency?: string;
   region?: string;
   period?: string;
   periodClassName?: string;
+  className?: string;
 }
 
-export function PolicyMetaRow({ agency, region, period, periodClassName }: PolicyMetaRowProps) {
+export function PolicyMetaRow({ agency, region, period, periodClassName, className }: PolicyMetaRowProps) {
   return (
-    <div className="flex flex-wrap items-center gap-4 text-sm text-[var(--muted-foreground)]">
+    <div className={cn('flex items-center gap-4 text-sm text-[var(--muted-foreground)] overflow-hidden', className)}>
       {agency && (
-        <div className="flex items-center gap-1.5">
-          <Building2 className="h-4 w-4" />
-          <span>{agency}</span>
+        <div className="flex items-center gap-1.5 min-w-0 flex-shrink-0">
+          <Building2 className="h-4 w-4 flex-shrink-0" />
+          <span className="truncate max-w-[160px]">{agency}</span>
         </div>
       )}
       {region && (
-        <div className="flex items-center gap-1.5">
-          <MapPin className="h-4 w-4" />
+        <div className="flex items-center gap-1.5 flex-shrink-0 whitespace-nowrap">
+          <MapPin className="h-4 w-4 flex-shrink-0" />
           <span>{region}</span>
         </div>
       )}
       {period && (
-        <div className={`flex items-center gap-1.5${periodClassName ? ` ${periodClassName}` : ''}`}>
-          <Calendar className="h-4 w-4" />
+        <div className={`flex items-center gap-1.5 flex-shrink-0 whitespace-nowrap${periodClassName ? ` ${periodClassName}` : ''}`}>
+          <Calendar className="h-4 w-4 flex-shrink-0" />
           <span>{period}</span>
         </div>
       )}

--- a/frontend/src/app/components/molecules/SortDropdown.tsx
+++ b/frontend/src/app/components/molecules/SortDropdown.tsx
@@ -1,5 +1,5 @@
-import { ChevronDown } from 'lucide-react';
 import { cn } from '../../lib/utils';
+import { CustomSelect } from '../atoms/CustomSelect';
 
 export type SortOption = 'latest' | 'deadline' | 'recommended';
 
@@ -9,25 +9,20 @@ export interface SortDropdownProps {
   className?: string;
 }
 
-const sortLabels: Record<SortOption, string> = {
-  latest: '최신순',
-  deadline: '마감임박순',
-  recommended: '추천순',
-};
+const sortOptions = [
+  { value: 'latest', label: '최신순' },
+  { value: 'deadline', label: '마감임박순' },
+  { value: 'recommended', label: '추천순' },
+];
 
 export function SortDropdown({ value, onChange, className }: SortDropdownProps) {
   return (
-    <div className={cn('relative', className)}>
-      <select
+    <div className={cn('w-36', className)}>
+      <CustomSelect
         value={value}
-        onChange={(e) => onChange(e.target.value as SortOption)}
-        className="appearance-none rounded-xl border border-[var(--border)] bg-white px-4 py-2 pr-10 text-sm cursor-pointer hover:border-[var(--accent)] transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
-      >
-        <option value="latest">{sortLabels.latest}</option>
-        <option value="deadline">{sortLabels.deadline}</option>
-        <option value="recommended">{sortLabels.recommended}</option>
-      </select>
-      <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[var(--muted-foreground)] pointer-events-none" />
+        onChange={(v) => onChange(v as SortOption)}
+        options={sortOptions}
+      />
     </div>
   );
 }

--- a/frontend/src/app/components/organisms/Header.tsx
+++ b/frontend/src/app/components/organisms/Header.tsx
@@ -103,7 +103,7 @@ export function Header() {
           </div>
           {isAuthenticated ? (
             <>
-              <Link to="/me" className="hidden sm:flex items-center gap-1.5 text-sm font-medium text-[var(--foreground)] hover:text-[var(--accent)] transition-colors">
+              <Link to="/profile" className="hidden sm:flex items-center gap-1.5 text-sm font-medium text-[var(--foreground)] hover:text-[var(--accent)] transition-colors">
                 <User className="h-4 w-4" aria-hidden="true" />
                 {userName}
               </Link>

--- a/frontend/src/app/components/organisms/PolicyCard.tsx
+++ b/frontend/src/app/components/organisms/PolicyCard.tsx
@@ -4,8 +4,89 @@ import { Badge } from '../atoms/Badge';
 import { PolicyMetaRow } from '../molecules/PolicyMetaRow';
 import { cn } from '../../lib/utils';
 import { motion } from 'motion/react';
-import { useState } from 'react';
+import { useState, useRef, useLayoutEffect, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import type { PolicyListItem } from '../../types';
+
+interface BadgeItem { key: string; label: string; el: React.ReactNode; }
+
+function BadgeRow({ badges }: { badges: BadgeItem[] }) {
+  const measureRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const plusRef = useRef<HTMLSpanElement>(null);
+  const [maxVisible, setMaxVisible] = useState(badges.length);
+  const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null);
+
+  useLayoutEffect(() => {
+    const measure = () => {
+      const container = containerRef.current;
+      const measureEl = measureRef.current;
+      if (!container || !measureEl) return;
+      const spans = Array.from(measureEl.querySelectorAll<HTMLElement>('[data-b]'));
+      const containerW = container.clientWidth;
+      const GAP = 8;
+      const PLUS_W = 28;
+      let w = 0, count = 0;
+      for (let i = 0; i < spans.length; i++) {
+        const sw = spans[i].offsetWidth + (i > 0 ? GAP : 0);
+        if (w + sw + (i === spans.length - 1 ? 0 : PLUS_W + GAP) > containerW) break;
+        w += sw; count++;
+      }
+      setMaxVisible(Math.max(1, count));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    if (containerRef.current) ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, [badges.length]);
+
+  const hiddenBadges = badges.slice(maxVisible);
+
+  const showTooltip = () => {
+    const el = plusRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    setTooltipPos({ x: rect.right + 8, y: rect.top + rect.height / 2 });
+  };
+
+  const hideTooltip = () => setTooltipPos(null);
+
+  useEffect(() => {
+    const onScroll = () => setTooltipPos(null);
+    window.addEventListener('scroll', onScroll, true);
+    return () => window.removeEventListener('scroll', onScroll, true);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="relative flex gap-2 mb-3 items-center h-6">
+      <div ref={measureRef} className="absolute invisible flex gap-2 items-center pointer-events-none" aria-hidden="true">
+        {badges.map(b => <span key={b.key} data-b className="flex-shrink-0">{b.el}</span>)}
+      </div>
+      {badges.slice(0, maxVisible).map(b => (
+        <span key={b.key} className="flex-shrink-0">{b.el}</span>
+      ))}
+      {hiddenBadges.length > 0 && (
+        <span
+          ref={plusRef}
+          className="text-xs text-[var(--muted-foreground)] font-medium cursor-default select-none flex-shrink-0"
+          onMouseEnter={showTooltip}
+          onMouseLeave={hideTooltip}
+        >
+          +{hiddenBadges.length}
+        </span>
+      )}
+      {tooltipPos && hiddenBadges.length > 0 && createPortal(
+        <div
+          className="fixed flex flex-col gap-1.5 bg-white border border-[var(--border)] rounded-xl px-3 py-2.5 shadow-lg z-[9999] pointer-events-none whitespace-nowrap"
+          style={{ left: tooltipPos.x, top: tooltipPos.y, transform: 'translateY(-50%)' }}
+        >
+          {hiddenBadges.map(b => <span key={b.key}>{b.el}</span>)}
+        </div>,
+        document.body
+      )}
+    </div>
+  );
+}
 
 export interface PolicyCardProps extends PolicyListItem {
   applicationStatus?: 'upcoming' | 'recruiting' | 'closed';
@@ -79,9 +160,9 @@ export function PolicyCard({
   const eligibility = getEligibility(fitScore ?? null);
 
   const borderColors = {
-    recruiting: 'border-emerald-200 hover:border-emerald-400 hover:shadow-emerald-500/15',
-    always: 'border-blue-200 hover:border-blue-400 hover:shadow-blue-500/15',
-    closed: 'border-gray-300 hover:border-gray-400 hover:shadow-gray-500/10',
+    recruiting: 'border-emerald-500 hover:border-emerald-600 hover:shadow-emerald-500/25 bg-emerald-50/40',
+    always: 'border-blue-500 hover:border-blue-600 hover:shadow-blue-500/25 bg-blue-50/40',
+    closed: 'border-gray-500 hover:border-gray-600 hover:shadow-gray-500/20 bg-gray-50/60',
   };
 
   const handleBookmarkClick = (e: React.MouseEvent) => {
@@ -118,9 +199,9 @@ export function PolicyCard({
     <Link to={`/policies/${id}`} className="block h-full">
       <article
         className={cn(
-          'group relative bg-white border rounded-3xl p-6 sm:p-8 h-full flex flex-col',
+          'group relative border rounded-3xl p-6 sm:p-8 h-full flex flex-col overflow-hidden',
           'shadow-sm hover:shadow-xl',
-          status ? borderColors[status] : 'border-amber-200 hover:border-amber-400 hover:shadow-amber-500/15',
+          status ? borderColors[status] : 'border-amber-500 hover:border-amber-600 hover:shadow-amber-500/25 bg-amber-50/40',
           'hover:-translate-y-2',
           'transition-all duration-300 ease-out',
           className
@@ -130,35 +211,15 @@ export function PolicyCard({
         <div className="flex-1 flex flex-col">
         <div className="flex items-start justify-between gap-4 mb-4">
           <div className="flex-1">
-            <h3 className="group-hover:text-[var(--accent)] transition-colors duration-200 line-clamp-2 mb-3 leading-snug">
+            <h3 className="group-hover:text-[var(--accent)] transition-colors duration-200 line-clamp-2 leading-snug mb-3 min-h-[2.75em]">
               {title}
             </h3>
-            <div className="flex flex-wrap gap-2 mb-3">
-              {status && (
-                <Badge variant={status} aria-label={`모집 상태: ${statusLabels[status]}`}>
-                  {statusLabels[status]}
-                </Badge>
-              )}
-              {eligibility && (
-                <Badge
-                  variant={eligibilityVariants[eligibility]}
-                  aria-label={`신청 가능성: ${eligibilityLabels[eligibility]}`}
-                >
-                  {eligibilityLabels[eligibility]}
-                </Badge>
-              )}
-              <Badge variant="default" aria-label={`출처: ${providerName}`}>{providerName}</Badge>
-              {categories.map((category) => (
-                <Badge
-                  key={category}
-                  variant="default"
-                  className="bg-blue-50 text-blue-700 border-blue-200"
-                  aria-label={`카테고리: ${categoryLabels[category] || category}`}
-                >
-                  {categoryLabels[category] || category}
-                </Badge>
-              ))}
-            </div>
+            <BadgeRow badges={[
+              ...(status ? [{ key: 'status', label: statusLabels[status], el: <Badge variant={status}>{statusLabels[status]}</Badge> }] : []),
+              { key: 'provider', label: providerName, el: <Badge variant="default"><span className="max-w-[120px] truncate block">{providerName}</span></Badge> },
+              ...categories.map((c) => ({ key: c, label: categoryLabels[c] || c, el: <Badge variant="default" className="bg-blue-50 text-blue-700 border-blue-200">{categoryLabels[c] || c}</Badge> })),
+              ...(eligibility ? [{ key: 'eligibility', label: eligibilityLabels[eligibility], el: <Badge variant={eligibilityVariants[eligibility]}>{eligibilityLabels[eligibility]}</Badge> }] : []),
+            ]} />
           </div>
           {onBookmark && (
             <motion.button
@@ -181,14 +242,13 @@ export function PolicyCard({
           )}
         </div>
 
-        <p className="text-[var(--muted-foreground)] text-sm line-clamp-2 mb-5 leading-relaxed">
+        <p className="text-[var(--muted-foreground)] text-sm line-clamp-2 leading-relaxed mb-5">
           {shortDescription || '요약 정보가 없습니다.'}
         </p>
         </div>
 
         <div className="flex items-end justify-between gap-2">
           <PolicyMetaRow
-            agency={providerName}
             region={regionCodes.map((code) => regionLabels[code] ?? code).join(', ')}
             period={formatPolicyPeriod(startsAt, endsAt, isAlwaysOpen)}
             periodClassName={!isAlwaysOpen && !(startsAt && endsAt) ? 'text-red-500' : undefined}

--- a/frontend/src/app/pages/MyPage.tsx
+++ b/frontend/src/app/pages/MyPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { User, MapPin, Sparkles, Edit, Trash2, X } from 'lucide-react';
-import { Link } from 'react-router';
+import { Link, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 import { getPolicyDetail } from '../api/policies';
 import { ApiClientError, getStoredUserProfile, setStoredUserProfile } from '../api/client';
@@ -10,6 +10,7 @@ import { Button } from '../components/atoms/Button';
 import { Badge } from '../components/atoms/Badge';
 import { Input } from '../components/atoms/Input';
 import { PolicyCard, PolicyCardProps } from '../components/organisms/PolicyCard';
+import { CustomSelect } from '../components/atoms/CustomSelect';
 import { EmptyState } from '../components/molecules/EmptyState';
 import type { MyPolicyItem, PolicyDetail, UserProfileSummary } from '../types';
 
@@ -97,8 +98,17 @@ function mapStoredUserToView(user: UserProfileSummary | null): UserProfileView |
   };
 }
 
+const PAGE_SIZE = 12;
+
 export function MyPage() {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = Math.max(1, Number(searchParams.get('page') ?? '1'));
+
+  const setCurrentPage = (page: number) => {
+    setSearchParams((prev) => { prev.set('page', String(page)); return prev; }, { replace: true });
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  };
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [policyToDelete, setPolicyToDelete] = useState<string | null>(null);
   const [editProfileOpen, setEditProfileOpen] = useState(false);
@@ -265,7 +275,7 @@ export function MyPage() {
 
           <div className="bg-white rounded-xl p-2 mb-6 flex flex-wrap gap-2">
             <button
-              onClick={() => setStatusFilter('all')}
+              onClick={() => { setStatusFilter('all'); setCurrentPage(1); }}
               className={`px-4 py-2 rounded-lg text-sm transition-colors ${
                 statusFilter === 'all' ? 'bg-[var(--accent)] text-[var(--accent-foreground)]' : 'hover:bg-[var(--muted)]'
               }`}
@@ -273,7 +283,7 @@ export function MyPage() {
               전체 ({statusCounts.all})
             </button>
             <button
-              onClick={() => setStatusFilter('upcoming')}
+              onClick={() => { setStatusFilter('upcoming'); setCurrentPage(1); }}
               className={`px-4 py-2 rounded-lg text-sm transition-colors ${
                 statusFilter === 'upcoming' ? 'bg-[var(--accent)] text-[var(--accent-foreground)]' : 'hover:bg-[var(--muted)]'
               }`}
@@ -281,7 +291,7 @@ export function MyPage() {
               예정 ({statusCounts.upcoming})
             </button>
             <button
-              onClick={() => setStatusFilter('recruiting')}
+              onClick={() => { setStatusFilter('recruiting'); setCurrentPage(1); }}
               className={`px-4 py-2 rounded-lg text-sm transition-colors ${
                 statusFilter === 'recruiting' ? 'bg-[var(--accent)] text-[var(--accent-foreground)]' : 'hover:bg-[var(--muted)]'
               }`}
@@ -289,7 +299,7 @@ export function MyPage() {
               모집중 ({statusCounts.recruiting})
             </button>
             <button
-              onClick={() => setStatusFilter('closed')}
+              onClick={() => { setStatusFilter('closed'); setCurrentPage(1); }}
               className={`px-4 py-2 rounded-lg text-sm transition-colors ${
                 statusFilter === 'closed' ? 'bg-[var(--accent)] text-[var(--accent-foreground)]' : 'hover:bg-[var(--muted)]'
               }`}
@@ -310,10 +320,11 @@ export function MyPage() {
               </Link>
             </div>
           ) : (
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              {filteredPolicies.map((policy) => (
+            <div>
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                {filteredPolicies.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE).map((policy) => (
                 <div key={policy.id} className="relative">
-                  <PolicyCard {...policy} />
+                  <PolicyCard {...policy} applicationStatus={!policy.startsAt && !policy.endsAt && !policy.isAlwaysOpen ? undefined : policy.applicationStatus} />
                   <div className="absolute bottom-4 right-4 z-10">
                     <button
                       className="p-2 bg-white/95 hover:bg-gray-50 border border-gray-300 hover:border-gray-400 rounded-xl shadow-sm transition-all duration-200 active:scale-95 backdrop-blur-sm"
@@ -328,25 +339,42 @@ export function MyPage() {
                       <Trash2 className="h-4 w-4 text-gray-500" />
                     </button>
                   </div>
-                  <div className="absolute top-4 right-4 z-10">
-                    <Badge
-                      variant={
-                        policy.applicationStatus === 'closed'
-                          ? 'ineligible'
-                          : policy.applicationStatus === 'recruiting'
-                          ? 'recruiting'
-                          : 'default'
-                      }
-                    >
-                      {policy.applicationStatus === 'upcoming'
-                        ? '예정'
-                        : policy.applicationStatus === 'recruiting'
-                        ? '모집중'
-                        : '마감'}
-                    </Badge>
-                  </div>
+                  {(() => {
+                    const s = policy.isAlwaysOpen ? 'always'
+                      : !policy.endsAt ? null
+                      : new Date(policy.endsAt).getTime() < Date.now() ? 'closed'
+                      : 'recruiting';
+                    const labels = { recruiting: '모집중', always: '상시', closed: '마감' } as const;
+                    return s ? (
+                      <div className="absolute top-4 right-4 z-10">
+                        <Badge variant={s}>{labels[s]}</Badge>
+                      </div>
+                    ) : null;
+                  })()}
                 </div>
-              ))}
+                ))}
+              </div>
+              {Math.ceil(filteredPolicies.length / PAGE_SIZE) > 1 && (
+                <div className="flex items-center justify-center gap-2 mt-10">
+                  <Button
+                    variant="secondary"
+                    onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
+                    disabled={currentPage === 1}
+                  >
+                    이전
+                  </Button>
+                  <span className="text-sm text-[var(--muted-foreground)] px-2">
+                    {currentPage} / {Math.ceil(filteredPolicies.length / PAGE_SIZE)}
+                  </span>
+                  <Button
+                    variant="secondary"
+                    onClick={() => setCurrentPage(Math.min(Math.ceil(filteredPolicies.length / PAGE_SIZE), currentPage + 1))}
+                    disabled={currentPage === Math.ceil(filteredPolicies.length / PAGE_SIZE)}
+                  >
+                    다음
+                  </Button>
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -409,16 +437,11 @@ export function MyPage() {
               </div>
               <div>
                 <label className="block text-sm font-medium mb-2">지역</label>
-                <select
-                  className="w-full border border-[var(--border)] rounded-xl px-3 py-2 text-sm bg-white"
+                <CustomSelect
                   value={editForm.regionCode}
-                  onChange={(e) => setEditForm((current) => ({ ...current, regionCode: e.target.value }))}
-                >
-                  <option value="">선택하세요</option>
-                  {REGION_OPTIONS.map((opt) => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
+                  onChange={(v) => setEditForm((current) => ({ ...current, regionCode: v }))}
+                  options={REGION_OPTIONS}
+                />
               </div>
               <div>
                 <label className="block text-sm font-medium mb-2">관심사</label>

--- a/frontend/src/app/pages/PersonalizedPoliciesPage.tsx
+++ b/frontend/src/app/pages/PersonalizedPoliciesPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router';
+import { Link, useSearchParams } from 'react-router';
 import { ArrowRight, MapPin, User as UserIcon, LogIn, Gift } from 'lucide-react';
 import { toast } from 'sonner';
 import { getPoliciesRecommended } from '../api/policies';
@@ -22,11 +22,20 @@ const regionCodeByLabel: Record<string, string> = Object.fromEntries(
   Object.entries(regionLabels).map(([code, label]) => [label, code]),
 );
 
+const PAGE_SIZE = 12;
+
 export function PersonalizedPoliciesPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
   const [personalizedPolicies, setPersonalizedPolicies] = useState<PolicyListItem[]>([]);
   const [reloadKey, setReloadKey] = useState(0);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = Math.max(1, Number(searchParams.get('page') ?? '1'));
+
+  const setCurrentPage = (page: number) => {
+    setSearchParams((prev) => { prev.set('page', String(page)); return prev; }, { replace: true });
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  };
 
   const isAuthenticated = Boolean(getAccessToken() && getStoredUserProfile());
   const user = getStoredUserProfile();
@@ -263,7 +272,35 @@ export function PersonalizedPoliciesPage() {
         )}
 
         {!isLoading && !hasError && personalizedPolicies.length > 0 && (
-          <PolicyList policies={personalizedPolicies} hasMore={false} />
+          <div className="flex flex-col min-h-[800px]">
+            <div className="flex-1">
+              <PolicyList
+                policies={personalizedPolicies.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)}
+                hasMore={false}
+              />
+            </div>
+            {Math.ceil(personalizedPolicies.length / PAGE_SIZE) > 1 && (
+              <div className="flex items-center justify-center gap-2 mt-10">
+                <Button
+                  variant="secondary"
+                  onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
+                  disabled={currentPage === 1}
+                >
+                  이전
+                </Button>
+                <span className="text-sm text-[var(--muted-foreground)] px-2">
+                  {currentPage} / {Math.ceil(personalizedPolicies.length / PAGE_SIZE)}
+                </span>
+                <Button
+                  variant="secondary"
+                  onClick={() => setCurrentPage(Math.min(Math.ceil(personalizedPolicies.length / PAGE_SIZE), currentPage + 1))}
+                  disabled={currentPage === Math.ceil(personalizedPolicies.length / PAGE_SIZE)}
+                >
+                  다음
+                </Button>
+              </div>
+            )}
+          </div>
         )}
       </div>
     </MainLayout>

--- a/frontend/src/app/pages/PoliciesPage.tsx
+++ b/frontend/src/app/pages/PoliciesPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router';
 import { Filter } from 'lucide-react';
 import { toast } from 'sonner';
 import { motion, AnimatePresence } from 'motion/react';
@@ -39,7 +40,14 @@ export function PoliciesPage() {
   const [hasError, setHasError] = useState(false);
   const [policies, setPolicies] = useState<PolicyListItem[]>([]);
   const [reloadKey, setReloadKey] = useState(0);
-  const [currentPage, setCurrentPage] = useState(1);
+  const [statusFilter, setStatusFilter] = useState<'recruiting' | 'always' | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = Math.max(1, Number(searchParams.get('page') ?? '1'));
+
+  const setCurrentPage = (page: number) => {
+    setSearchParams((prev) => { prev.set('page', String(page)); return prev; }, { replace: true });
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  };
 
   useEffect(() => {
     const loadPolicies = async () => {
@@ -59,7 +67,6 @@ export function PoliciesPage() {
         });
 
         setPolicies(response.items);
-        setCurrentPage(1);
       } catch (error) {
         setHasError(true);
         const message = error instanceof ApiClientError ? error.message : '정책 목록을 불러오는데 실패했습니다';
@@ -73,10 +80,12 @@ export function PoliciesPage() {
   }, [searchQuery, sortBy, selectedFilters, expandableFilters, reloadKey]);
 
   const handleSearch = async (query: string) => {
+    setCurrentPage(1);
     setSearchQuery(query);
   };
 
   const handleFilterChange = (filters: string[]) => {
+    setCurrentPage(1);
     setSelectedFilters(filters);
     const applied = filters.map((id) => ({
       id,
@@ -174,7 +183,8 @@ export function PoliciesPage() {
       !f.id.startsWith('recruit-')
     );
     setAppliedFilters([...categoryFilters, ...newFilters]);
-    
+    setCurrentPage(1);
+
     if (newFilters.length > 0) {
       toast.success('필터가 적용되었습니다');
     }
@@ -186,6 +196,11 @@ export function PoliciesPage() {
 
   const recruitingCount = policies.filter(p => !p.isAlwaysOpen && p.endsAt && new Date(p.endsAt).getTime() >= Date.now()).length;
   const alwaysOpenCount = policies.filter(p => p.isAlwaysOpen).length;
+  const filteredPolicies = statusFilter === 'recruiting'
+    ? policies.filter(p => !p.isAlwaysOpen && p.endsAt && new Date(p.endsAt).getTime() >= Date.now())
+    : statusFilter === 'always'
+    ? policies.filter(p => p.isAlwaysOpen)
+    : policies;
 
   return (
     <MainLayout>
@@ -203,16 +218,16 @@ export function PoliciesPage() {
                 </p>
                 <div className="flex items-center gap-2 text-xs">
                   {recruitingCount > 0 && (
-                    <span className="flex items-center gap-1.5 px-2.5 py-1 bg-emerald-50 text-emerald-700 font-semibold rounded-full border border-emerald-200">
+                    <button type="button" onClick={() => { setStatusFilter(p => p === 'recruiting' ? null : 'recruiting'); setCurrentPage(1); }} className={`flex items-center gap-1.5 px-2.5 py-1 font-semibold rounded-full border transition-all ${statusFilter === 'recruiting' ? 'bg-emerald-200 border-emerald-400 text-emerald-800' : 'bg-emerald-50 text-emerald-700 border-emerald-200 hover:opacity-80'}`}>
                       <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 inline-block" />
                       모집중 {recruitingCount}
-                    </span>
+                    </button>
                   )}
                   {alwaysOpenCount > 0 && (
-                    <span className="flex items-center gap-1.5 px-2.5 py-1 bg-blue-50 text-blue-700 font-semibold rounded-full border border-blue-200">
+                    <button type="button" onClick={() => { setStatusFilter(p => p === 'always' ? null : 'always'); setCurrentPage(1); }} className={`flex items-center gap-1.5 px-2.5 py-1 font-semibold rounded-full border transition-all ${statusFilter === 'always' ? 'bg-blue-200 border-blue-400 text-blue-800' : 'bg-blue-50 text-blue-700 border-blue-200 hover:opacity-80'}`}>
                       <span className="w-1.5 h-1.5 rounded-full bg-blue-500 inline-block" />
                       상시 {alwaysOpenCount}
-                    </span>
+                    </button>
                   )}
                 </div>
               </div>
@@ -280,9 +295,9 @@ export function PoliciesPage() {
         {!isLoading && !hasError && policies.length > 0 && (
           <div className="mb-6">
             <p className="text-[var(--muted-foreground)]">
-              총 <span className="text-[var(--foreground)] font-semibold">{policies.length}개</span>의 정책
-              {Math.ceil(policies.length / PAGE_SIZE) > 1 && (
-                <span> · {currentPage}/{Math.ceil(policies.length / PAGE_SIZE)} 페이지</span>
+              총 <span className="text-[var(--foreground)] font-semibold">{filteredPolicies.length}개</span>의 정책
+              {Math.ceil(filteredPolicies.length / PAGE_SIZE) > 1 && (
+                <span> · {currentPage}/{Math.ceil(filteredPolicies.length / PAGE_SIZE)} 페이지</span>
               )}
             </p>
           </div>
@@ -319,39 +334,42 @@ export function PoliciesPage() {
             </motion.div>
           )}
 
-          {!isLoading && !hasError && policies.length === 0 && (
+          {!isLoading && !hasError && filteredPolicies.length === 0 && (
             <motion.div key="empty" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
               <EmptyState type="noResult" onAction={handleClearAll} actionLabel="필터 초기화" />
             </motion.div>
           )}
 
-          {!isLoading && !hasError && policies.length > 0 && (
+          {!isLoading && !hasError && filteredPolicies.length > 0 && (
             <motion.div
               key="results"
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.25 }}
+              className="flex flex-col min-h-[800px]"
             >
-              <PolicyList
-                policies={policies.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)}
-                hasMore={false}
-              />
-              {Math.ceil(policies.length / PAGE_SIZE) > 1 && (
+              <div className="flex-1">
+                <PolicyList
+                  policies={filteredPolicies.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)}
+                  hasMore={false}
+                />
+              </div>
+              {Math.ceil(filteredPolicies.length / PAGE_SIZE) > 1 && (
                 <div className="flex items-center justify-center gap-2 mt-10">
                   <Button
                     variant="secondary"
-                    onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                    onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
                     disabled={currentPage === 1}
                   >
                     이전
                   </Button>
                   <span className="text-sm text-[var(--muted-foreground)] px-2">
-                    {currentPage} / {Math.ceil(policies.length / PAGE_SIZE)}
+                    {currentPage} / {Math.ceil(filteredPolicies.length / PAGE_SIZE)}
                   </span>
                   <Button
                     variant="secondary"
-                    onClick={() => setCurrentPage((p) => Math.min(Math.ceil(policies.length / PAGE_SIZE), p + 1))}
-                    disabled={currentPage === Math.ceil(policies.length / PAGE_SIZE)}
+                    onClick={() => setCurrentPage(Math.min(Math.ceil(filteredPolicies.length / PAGE_SIZE), currentPage + 1))}
+                    disabled={currentPage === Math.ceil(filteredPolicies.length / PAGE_SIZE)}
                   >
                     다음
                   </Button>

--- a/frontend/src/app/pages/PolicyDetailPage.tsx
+++ b/frontend/src/app/pages/PolicyDetailPage.tsx
@@ -3,6 +3,9 @@ import { useParams, Link, useNavigate } from 'react-router';
 import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const remarkGfmNoSingleTilde = [remarkGfm, { singleTilde: false }] as any;
 import {
   Bookmark,
   ExternalLink,
@@ -36,6 +39,7 @@ import { EmptyState } from '../components/molecules/EmptyState';
 import { PolicyCard } from '../components/organisms/PolicyCard';
 import type { EligibilityResponse, PolicyDetail as ApiPolicyDetail, PolicyListItem } from '../types';
 import { cn } from '../lib/utils';
+import { CustomSelect } from '../components/atoms/CustomSelect';
 
 const statusLabels: Record<string, string> = {
   recruiting: '모집중',
@@ -129,6 +133,13 @@ export function PolicyDetailPage() {
   const mockViews = useMemo(() => Math.floor(Math.random() * 1500) + 500, []);
 
   useEffect(() => {
+    setEligibilityResult(null);
+    setShowEligibilityForm(false);
+    setEligibilityAnswers({});
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  }, [id]);
+
+  useEffect(() => {
     const loadPolicy = async () => {
       if (!id) { setHasError(true); setIsLoading(false); return; }
       setIsLoading(true);
@@ -193,7 +204,6 @@ export function PolicyDetailPage() {
       const response = await checkEligibility(id, { answers });
       setEligibilityResult(response);
       toast.success('자격 확인이 완료되었습니다');
-      setTimeout(() => { document.getElementById('evidence')?.scrollIntoView({ behavior: 'smooth' }); }, 300);
     } catch (error) {
       const message = error instanceof ApiClientError ? error.message : '자격 확인에 실패했습니다';
       toast.error(message);
@@ -315,6 +325,7 @@ export function PolicyDetailPage() {
               region={policy.regionCodes?.map((code) => regionLabels[code] ?? code).join(', ')}
               period={formatPolicyPeriod(policy.startsAt, policy.endsAt, policy.isAlwaysOpen)}
               periodClassName={!policy.isAlwaysOpen && !(policy.startsAt && policy.endsAt) ? 'text-red-500' : undefined}
+              className="flex-wrap overflow-visible"
             />
 
             {/* 혜택 하이라이트 */}
@@ -324,7 +335,7 @@ export function PolicyDetailPage() {
                 <div className="flex-1 min-w-0">
                   <p className="text-xs font-medium text-blue-500 mb-0.5">지원 혜택</p>
                   <div className="prose prose-sm max-w-none text-blue-900 text-sm">
-                    <ReactMarkdown remarkPlugins={[remarkBreaks, remarkGfm]}>{supportContent}</ReactMarkdown>
+                    <ReactMarkdown remarkPlugins={[remarkBreaks, remarkGfmNoSingleTilde]}>{supportContent}</ReactMarkdown>
                   </div>
                 </div>
               </div>
@@ -381,7 +392,7 @@ export function PolicyDetailPage() {
                 <h2 className="text-xl font-semibold">요약</h2>
               </div>
               <div className="prose prose-sm max-w-none text-[var(--muted-foreground)]">
-                <ReactMarkdown remarkPlugins={[remarkBreaks, remarkGfm]}>{policy.shortDescription ?? policy.description ?? '요약 정보가 없습니다.'}</ReactMarkdown>
+                <ReactMarkdown remarkPlugins={[remarkBreaks, remarkGfmNoSingleTilde]}>{policy.shortDescription ?? policy.description ?? '요약 정보가 없습니다.'}</ReactMarkdown>
               </div>
             </motion.section>
 
@@ -400,7 +411,7 @@ export function PolicyDetailPage() {
                 <h2 className="text-xl font-semibold">지원대상</h2>
               </div>
               <div className="prose prose-sm max-w-none text-[var(--muted-foreground)]">
-                <ReactMarkdown remarkPlugins={[remarkBreaks, remarkGfm]}>{getTargetText(policy)}</ReactMarkdown>
+                <ReactMarkdown remarkPlugins={[remarkBreaks, remarkGfmNoSingleTilde]}>{getTargetText(policy)}</ReactMarkdown>
               </div>
             </motion.section>
 
@@ -420,7 +431,7 @@ export function PolicyDetailPage() {
                   <h2 className="text-xl font-semibold">선정기준</h2>
                 </div>
                 <div className="prose prose-sm max-w-none text-[var(--foreground)]">
-                  <ReactMarkdown remarkPlugins={[remarkBreaks, remarkGfm]}>{selectionCriteria}</ReactMarkdown>
+                  <ReactMarkdown remarkPlugins={[remarkBreaks, remarkGfmNoSingleTilde]}>{selectionCriteria}</ReactMarkdown>
                 </div>
               </motion.section>
             )}
@@ -502,15 +513,11 @@ export function PolicyDetailPage() {
                             {req.isRequired && <span className="text-[var(--destructive)] ml-1">*</span>}
                           </label>
                           {req.type === 'select' && req.options ? (
-                            <select
-                              id={`req-${req.key}`}
-                              className="w-full border border-[var(--border)] rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                            <CustomSelect
                               value={eligibilityAnswers[req.key] ?? ''}
-                              onChange={(e) => setEligibilityAnswers((prev) => ({ ...prev, [req.key]: e.target.value }))}
-                            >
-                              <option value="">선택하세요</option>
-                              {req.options.map((opt) => <option key={opt} value={opt}>{opt}</option>)}
-                            </select>
+                              onChange={(v) => setEligibilityAnswers((prev) => ({ ...prev, [req.key]: v }))}
+                              options={req.options.map((opt) => ({ value: opt, label: opt }))}
+                            />
                           ) : req.type === 'boolean' ? (
                             <div className="flex gap-2">
                               {(['true', 'false'] as const).map((val) => (
@@ -625,7 +632,7 @@ export function PolicyDetailPage() {
                     className="bg-[var(--muted)] rounded-xl p-4 hover:bg-amber-50 transition-colors duration-200 border border-transparent hover:border-amber-200"
                   >
                     <div className="prose prose-sm max-w-none mb-2">
-                      <ReactMarkdown remarkPlugins={[remarkBreaks, remarkGfm]}>{item.text}</ReactMarkdown>
+                      <ReactMarkdown remarkPlugins={[remarkBreaks, remarkGfmNoSingleTilde]}>{item.text}</ReactMarkdown>
                     </div>
                     <p className="text-sm text-[var(--muted-foreground)] flex items-center gap-1.5">
                       <FileText className="h-3.5 w-3.5" />출처: {item.source}

--- a/frontend/src/app/pages/ProfilePage.tsx
+++ b/frontend/src/app/pages/ProfilePage.tsx
@@ -1,0 +1,165 @@
+import { Link } from 'react-router';
+import { User, MapPin, Sparkles, Edit2, Bookmark, ChevronRight, Gift, Settings } from 'lucide-react';
+import { MainLayout } from '../components/templates/MainLayout';
+import { Button } from '../components/atoms/Button';
+import { Badge } from '../components/atoms/Badge';
+import { getStoredUserProfile } from '../api/client';
+
+const regionLabels: Record<string, string> = {
+  seoul: '서울',
+  seoul_gangnam: '서울 강남구',
+  seoul_mapo: '서울 마포구',
+  seoul_songpa: '서울 송파구',
+};
+
+const interestLabels: Record<string, string> = {
+  youth_policy: '청년정책',
+  childcare_policy: '육아정책',
+};
+
+export function ProfilePage() {
+  const user = getStoredUserProfile();
+  const userName = user ? user.email.split('@')[0] : '사용자';
+  const region = user ? (regionLabels[user.regionCode] ?? user.regionCode) : null;
+  const interests = user ? user.interests.map((i) => interestLabels[i] ?? i) : [];
+
+  return (
+    <MainLayout>
+      {/* 헤더 배너 */}
+      <div className="bg-gradient-to-br from-blue-600 via-indigo-600 to-purple-600 h-36 sm:h-44 relative">
+        <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGNpcmNsZSBjeD0iMzAiIGN5PSIzMCIgcj0iMiIgZmlsbD0icmdiYSgyNTUsMjU1LDI1NSwwLjA4KSIvPjwvc3ZnPg==')] opacity-60" />
+      </div>
+
+      <div className="container mx-auto px-4">
+        {/* 아바타 + 이름 영역 */}
+        <div className="relative flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 -mt-14 mb-6">
+          <div className="flex items-end gap-4">
+            <div className="w-24 h-24 sm:w-28 sm:h-28 rounded-2xl bg-gradient-to-br from-blue-100 to-indigo-200 border-4 border-white shadow-lg flex items-center justify-center flex-shrink-0">
+              <User className="h-12 w-12 sm:h-14 sm:h-14 text-blue-500" />
+            </div>
+            <div className="pb-1">
+              <h1 className="text-xl sm:text-2xl font-bold text-[var(--foreground)]">{userName}</h1>
+              <p className="text-sm text-[var(--muted-foreground)]">{user?.email ?? ''}</p>
+            </div>
+          </div>
+          <div className="flex gap-2 sm:pb-1">
+            <Link to="/me">
+              <Button variant="secondary" size="sm" className="gap-1.5">
+                <Bookmark className="h-4 w-4" />
+                저장 정책
+              </Button>
+            </Link>
+            <Button variant="secondary" size="sm" className="gap-1.5">
+              <Edit2 className="h-4 w-4" />
+              프로필 수정
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 pb-12">
+          {/* 왼쪽: 기본 정보 */}
+          <div className="lg:col-span-1 space-y-4">
+            {/* 기본 정보 카드 */}
+            <div className="bg-white rounded-2xl border border-[var(--border)] p-5 shadow-sm">
+              <h2 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wider mb-4">기본 정보</h2>
+              <div className="space-y-3">
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center flex-shrink-0">
+                    <Sparkles className="h-4 w-4 text-blue-500" />
+                  </div>
+                  <div>
+                    <p className="text-xs text-[var(--muted-foreground)]">나이</p>
+                    <p className="text-sm font-medium">{user?.age ? `${user.age}세` : '미입력'}</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-lg bg-emerald-50 flex items-center justify-center flex-shrink-0">
+                    <MapPin className="h-4 w-4 text-emerald-500" />
+                  </div>
+                  <div>
+                    <p className="text-xs text-[var(--muted-foreground)]">거주 지역</p>
+                    <p className="text-sm font-medium">{region ?? '미입력'}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* 관심사 카드 */}
+            <div className="bg-white rounded-2xl border border-[var(--border)] p-5 shadow-sm">
+              <h2 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wider mb-4">관심사</h2>
+              {interests.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {interests.map((interest) => (
+                    <Badge key={interest} variant="default" className="bg-blue-50 text-blue-700 border-blue-200">
+                      {interest}
+                    </Badge>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-[var(--muted-foreground)]">등록된 관심사가 없습니다</p>
+              )}
+            </div>
+
+            {/* 설정 링크 */}
+            <div className="bg-white rounded-2xl border border-[var(--border)] shadow-sm overflow-hidden">
+              <button className="w-full flex items-center justify-between px-5 py-4 hover:bg-[var(--muted)] transition-colors">
+                <div className="flex items-center gap-3">
+                  <Settings className="h-4 w-4 text-[var(--muted-foreground)]" />
+                  <span className="text-sm font-medium">계정 설정</span>
+                </div>
+                <ChevronRight className="h-4 w-4 text-[var(--muted-foreground)]" />
+              </button>
+            </div>
+          </div>
+
+          {/* 오른쪽: 활동 / 빠른 링크 */}
+          <div className="lg:col-span-2 space-y-4">
+            {/* 프로필 완성도 */}
+            <div className="bg-white rounded-2xl border border-[var(--border)] p-5 shadow-sm">
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-sm font-semibold">프로필 완성도</h2>
+                <span className="text-sm font-bold text-[var(--accent)]">
+                  {Math.round(((user?.age ? 1 : 0) + (user?.regionCode ? 1 : 0) + ((user?.interests.length ?? 0) > 0 ? 1 : 0)) / 3 * 100)}%
+                </span>
+              </div>
+              <div className="w-full bg-[var(--muted)] rounded-full h-2 mb-3">
+                <div
+                  className="bg-gradient-to-r from-blue-500 to-purple-500 h-2 rounded-full transition-all duration-500"
+                  style={{ width: `${Math.round(((user?.age ? 1 : 0) + (user?.regionCode ? 1 : 0) + ((user?.interests.length ?? 0) > 0 ? 1 : 0)) / 3 * 100)}%` }}
+                />
+              </div>
+              <p className="text-xs text-[var(--muted-foreground)]">프로필을 완성하면 더 정확한 맞춤 정책을 추천받을 수 있어요</p>
+            </div>
+
+            {/* 빠른 이동 */}
+            <div className="bg-white rounded-2xl border border-[var(--border)] shadow-sm overflow-hidden">
+              <div className="px-5 pt-5 pb-2">
+                <h2 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wider">바로가기</h2>
+              </div>
+              <Link to="/me" className="flex items-center justify-between px-5 py-4 hover:bg-[var(--muted)] transition-colors border-t border-[var(--border)]">
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center">
+                    <Bookmark className="h-4 w-4 text-blue-500" />
+                  </div>
+                  <span className="text-sm font-medium">저장한 정책 관리</span>
+                </div>
+                <ChevronRight className="h-4 w-4 text-[var(--muted-foreground)]" />
+              </Link>
+              <Link to="/personalized" className="flex items-center justify-between px-5 py-4 hover:bg-[var(--muted)] transition-colors border-t border-[var(--border)]">
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-lg bg-purple-50 flex items-center justify-center">
+                    <Gift className="h-4 w-4 text-purple-500" />
+                  </div>
+                  <span className="text-sm font-medium">나를 위한 맞춤 정책</span>
+                </div>
+                <ChevronRight className="h-4 w-4 text-[var(--muted-foreground)]" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </MainLayout>
+  );
+}
+
+export default ProfilePage;

--- a/frontend/src/app/routes.ts
+++ b/frontend/src/app/routes.ts
@@ -6,6 +6,7 @@ import { PolicyDetailPage } from './pages/PolicyDetailPage';
 import { MyPage } from './pages/MyPage';
 import { HomePage } from './pages/HomePage';
 import { PersonalizedPoliciesPage } from './pages/PersonalizedPoliciesPage';
+import { ProfilePage } from './pages/ProfilePage';
 
 export const router = createBrowserRouter([
   {
@@ -35,5 +36,9 @@ export const router = createBrowserRouter([
   {
     path: '/me',
     Component: MyPage,
+  },
+  {
+    path: '/profile',
+    Component: ProfilePage,
   },
 ]);


### PR DESCRIPTION
✨ 신규
CustomSelect 컴포넌트 추가 — native select를 커스텀 드롭다운으로 교체 (정렬, 지역, 자격확인 취업상태)
/profile 프로필 페이지 추가 — 헤더 이름 클릭 시 이동
🃏 정책카드
뱃지 overflow 수정 — 넘치는 뱃지 portal tooltip으로 표시
제목 2줄 높이 고정 → 카드 간 콘텐츠 위치 정렬
"정보부족" 뱃지 항상 마지막 순서
테두리 색상 강화 + 카드 배경 계열색 추가
🔍 정책찾기
"모집중 N / 상시 N" 뱃지 클릭 시 해당 정책만 필터링 (토글)
페이지네이션 시 상단 스크롤
📋 정책상세
자격확인 후 자동 스크롤 제거
다른 정책 이동 시 자격확인 상태 초기화 + 상단 스크롤
👤 마이페이지
저장 정책 상태 뱃지를 정책찾기와 동일한 조건으로 표시
날짜 없는 정책 → amber 테두리 정상 표시
페이지네이션 시 상단 스크롤