### PR TITLE
feat: periodRaw 표시 및 정책 필터 개선

### DIFF
--- a/frontend/src/app/components/organisms/PolicyCard.tsx
+++ b/frontend/src/app/components/organisms/PolicyCard.tsx
@@ -102,9 +102,10 @@ const regionLabels: Record<string, string> = {
   seoul_songpa: '서울 송파구',
 };
 
-function formatPolicyPeriod(startsAt: string | null, endsAt: string | null, isAlwaysOpen: boolean): string {
+function formatPolicyPeriod(startsAt: string | null, endsAt: string | null, isAlwaysOpen: boolean, periodRaw?: string | null): string {
   if (isAlwaysOpen) return '상시모집';
   if (startsAt && endsAt) return `${startsAt.slice(0, 10)} ~ ${endsAt.slice(0, 10)}`;
+  if (periodRaw) return periodRaw;
   return '기간확인불가';
 }
 
@@ -148,6 +149,7 @@ export function PolicyCard({
   startsAt,
   endsAt,
   isAlwaysOpen,
+  periodRaw,
   fitScore,
   categories = [],
   bookmarked,
@@ -201,7 +203,7 @@ export function PolicyCard({
         className={cn(
           'group relative border rounded-3xl p-6 sm:p-8 h-full flex flex-col overflow-hidden',
           'shadow-sm hover:shadow-xl',
-          status ? borderColors[status] : 'border-amber-500 hover:border-amber-600 hover:shadow-amber-500/25 bg-amber-50/40',
+          status ? borderColors[status] : periodRaw ? 'border-amber-500 hover:border-amber-600 hover:shadow-amber-500/25 bg-amber-50/40' : 'border-orange-500 hover:border-orange-600 hover:shadow-orange-500/30 bg-orange-100/70',
           'hover:-translate-y-2',
           'transition-all duration-300 ease-out',
           className
@@ -250,7 +252,7 @@ export function PolicyCard({
         <div className="flex items-end justify-between gap-2">
           <PolicyMetaRow
             region={regionCodes.map((code) => regionLabels[code] ?? code).join(', ')}
-            period={formatPolicyPeriod(startsAt, endsAt, isAlwaysOpen)}
+            period={formatPolicyPeriod(startsAt, endsAt, isAlwaysOpen, periodRaw)}
             periodClassName={!isAlwaysOpen && !(startsAt && endsAt) ? 'text-red-500' : undefined}
           />
           <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-all duration-200 flex-shrink-0" aria-hidden="true">

--- a/frontend/src/app/pages/MyPage.tsx
+++ b/frontend/src/app/pages/MyPage.tsx
@@ -78,6 +78,7 @@ function mapSavedPolicy(item: MyPolicyItem, detail: PolicyDetail): SavedPolicy {
     startsAt: detail.startsAt ?? null,
     endsAt: detail.endsAt ?? null,
     isAlwaysOpen: detail.isAlwaysOpen ?? false,
+    periodRaw: detail.periodRaw ?? null,
     fitScore: null,
     userState: item.state,
     bookmarked: item.state === 'saved',

--- a/frontend/src/app/pages/PoliciesPage.tsx
+++ b/frontend/src/app/pages/PoliciesPage.tsx
@@ -40,9 +40,28 @@ export function PoliciesPage() {
   const [hasError, setHasError] = useState(false);
   const [policies, setPolicies] = useState<PolicyListItem[]>([]);
   const [reloadKey, setReloadKey] = useState(0);
-  const [statusFilter, setStatusFilter] = useState<'recruiting' | 'always' | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = Math.max(1, Number(searchParams.get('page') ?? '1'));
+  const statusFilter = (searchParams.get('status') as 'recruiting' | 'always' | null) ?? null;
+  const typeFilter = (searchParams.get('type') as 'application' | 'info' | null) ?? null;
+
+  const setStatusFilter = (val: 'recruiting' | 'always' | null | ((prev: 'recruiting' | 'always' | null) => 'recruiting' | 'always' | null)) => {
+    setSearchParams((prev) => {
+      const next = typeof val === 'function' ? val(statusFilter) : val;
+      if (next) prev.set('status', next); else prev.delete('status');
+      prev.set('page', '1');
+      return prev;
+    }, { replace: true });
+  };
+
+  const setTypeFilter = (val: 'application' | 'info' | null | ((prev: 'application' | 'info' | null) => 'application' | 'info' | null)) => {
+    setSearchParams((prev) => {
+      const next = typeof val === 'function' ? val(typeFilter) : val;
+      if (next) prev.set('type', next); else prev.delete('type');
+      prev.set('page', '1');
+      return prev;
+    }, { replace: true });
+  };
 
   const setCurrentPage = (page: number) => {
     setSearchParams((prev) => { prev.set('page', String(page)); return prev; }, { replace: true });
@@ -196,11 +215,9 @@ export function PoliciesPage() {
 
   const recruitingCount = policies.filter(p => !p.isAlwaysOpen && p.endsAt && new Date(p.endsAt).getTime() >= Date.now()).length;
   const alwaysOpenCount = policies.filter(p => p.isAlwaysOpen).length;
-  const filteredPolicies = statusFilter === 'recruiting'
-    ? policies.filter(p => !p.isAlwaysOpen && p.endsAt && new Date(p.endsAt).getTime() >= Date.now())
-    : statusFilter === 'always'
-    ? policies.filter(p => p.isAlwaysOpen)
-    : policies;
+  const filteredPolicies = policies
+    .filter(p => !statusFilter || (statusFilter === 'recruiting' ? (!p.isAlwaysOpen && p.endsAt && new Date(p.endsAt).getTime() >= Date.now()) : p.isAlwaysOpen))
+    .filter(p => !typeFilter || (p as any).policyType === typeFilter);
 
   return (
     <MainLayout>
@@ -218,13 +235,13 @@ export function PoliciesPage() {
                 </p>
                 <div className="flex items-center gap-2 text-xs">
                   {recruitingCount > 0 && (
-                    <button type="button" onClick={() => { setStatusFilter(p => p === 'recruiting' ? null : 'recruiting'); setCurrentPage(1); }} className={`flex items-center gap-1.5 px-2.5 py-1 font-semibold rounded-full border transition-all ${statusFilter === 'recruiting' ? 'bg-emerald-200 border-emerald-400 text-emerald-800' : 'bg-emerald-50 text-emerald-700 border-emerald-200 hover:opacity-80'}`}>
+                    <button type="button" onClick={() => setStatusFilter(p => p === 'recruiting' ? null : 'recruiting')} className={`flex items-center gap-1.5 px-2.5 py-1 font-semibold rounded-full border transition-all ${statusFilter === 'recruiting' ? 'bg-emerald-200 border-emerald-400 text-emerald-800' : 'bg-emerald-50 text-emerald-700 border-emerald-200 hover:opacity-80'}`}>
                       <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 inline-block" />
                       모집중 {recruitingCount}
                     </button>
                   )}
                   {alwaysOpenCount > 0 && (
-                    <button type="button" onClick={() => { setStatusFilter(p => p === 'always' ? null : 'always'); setCurrentPage(1); }} className={`flex items-center gap-1.5 px-2.5 py-1 font-semibold rounded-full border transition-all ${statusFilter === 'always' ? 'bg-blue-200 border-blue-400 text-blue-800' : 'bg-blue-50 text-blue-700 border-blue-200 hover:opacity-80'}`}>
+                    <button type="button" onClick={() => setStatusFilter(p => p === 'always' ? null : 'always')} className={`flex items-center gap-1.5 px-2.5 py-1 font-semibold rounded-full border transition-all ${statusFilter === 'always' ? 'bg-blue-200 border-blue-400 text-blue-800' : 'bg-blue-50 text-blue-700 border-blue-200 hover:opacity-80'}`}>
                       <span className="w-1.5 h-1.5 rounded-full bg-blue-500 inline-block" />
                       상시 {alwaysOpenCount}
                     </button>
@@ -254,11 +271,27 @@ export function PoliciesPage() {
           </div>
 
           {/* Quick Filters */}
-          <FilterChipGroup
-            filters={quickFilters}
-            selected={selectedFilters}
-            onChange={handleFilterChange}
-          />
+          <div className="flex flex-wrap items-center gap-2">
+            <FilterChipGroup
+              filters={quickFilters}
+              selected={selectedFilters}
+              onChange={handleFilterChange}
+            />
+            <button
+              type="button"
+              onClick={() => setTypeFilter(p => p === 'application' ? null : 'application')}
+              className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-all ${typeFilter === 'application' ? 'bg-violet-500 text-white border-violet-500' : 'bg-violet-50 text-violet-700 border-violet-200 hover:opacity-80'}`}
+            >
+              신청형
+            </button>
+            <button
+              type="button"
+              onClick={() => setTypeFilter(p => p === 'info' ? null : 'info')}
+              className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-all ${typeFilter === 'info' ? 'bg-orange-500 text-white border-orange-500' : 'bg-orange-50 text-orange-700 border-orange-200 hover:opacity-80'}`}
+            >
+              정보형
+            </button>
+          </div>
 
           {/* Expandable Filters - Toggleable */}
           <AnimatePresence>

--- a/frontend/src/app/pages/PolicyDetailPage.tsx
+++ b/frontend/src/app/pages/PolicyDetailPage.tsx
@@ -54,9 +54,10 @@ const regionLabels: Record<string, string> = {
   seoul_songpa: '서울 송파구',
 };
 
-function formatPolicyPeriod(startsAt?: string | null, endsAt?: string | null, isAlwaysOpen?: boolean) {
+function formatPolicyPeriod(startsAt?: string | null, endsAt?: string | null, isAlwaysOpen?: boolean, periodRaw?: string | null) {
   if (isAlwaysOpen) return '상시모집';
   if (startsAt && endsAt) return `${startsAt.slice(0, 10)} ~ ${endsAt.slice(0, 10)}`;
+  if (periodRaw) return periodRaw;
   return '기간확인불가';
 }
 
@@ -323,7 +324,7 @@ export function PolicyDetailPage() {
             <PolicyMetaRow
               agency={policy.providerName}
               region={policy.regionCodes?.map((code) => regionLabels[code] ?? code).join(', ')}
-              period={formatPolicyPeriod(policy.startsAt, policy.endsAt, policy.isAlwaysOpen)}
+              period={formatPolicyPeriod(policy.startsAt, policy.endsAt, policy.isAlwaysOpen, policy.periodRaw)}
               periodClassName={!policy.isAlwaysOpen && !(policy.startsAt && policy.endsAt) ? 'text-red-500' : undefined}
               className="flex-wrap overflow-visible"
             />
@@ -707,6 +708,8 @@ export function PolicyDetailPage() {
                       <span className="font-bold text-sm text-rose-500">D-{daysLeft}</span>
                     ) : policy.isAlwaysOpen ? (
                       <span className="font-semibold text-sm text-emerald-600">상시모집</span>
+                    ) : policy.periodRaw ? (
+                      <span className="font-semibold text-sm text-[var(--muted-foreground)]">{policy.periodRaw}</span>
                     ) : (
                       <span className="font-semibold text-sm text-[var(--muted-foreground)]">기간 미정</span>
                     )}

--- a/frontend/src/app/types/policy.ts
+++ b/frontend/src/app/types/policy.ts
@@ -27,6 +27,7 @@ export interface PolicyListItem {
   startsAt: string | null;
   endsAt: string | null;
   isAlwaysOpen: boolean;
+  periodRaw?: string | null;
   fitScore?: number | null;
   userState?: UserPolicyState | null;
 }
@@ -68,6 +69,7 @@ export interface PolicyDetail {
   startsAt?: string | null;
   endsAt?: string | null;
   isAlwaysOpen?: boolean;
+  periodRaw?: string | null;
   minAge?: number | null;
   maxAge?: number | null;
   requirements?: PolicyRequirement[];


### PR DESCRIPTION
- periodRaw 있을 때 기간 원문 표시 (기간확인불가 대신)
- 기간확인불가 카드 주황색 스타일 적용
- 정책찾기에 신청형/정보형 타입 필터 추가
- 상태/타입 필터 URL params로 관리 (뒤로가기 지원)
- MyPage, PolicyDetailPage periodRaw 매핑 추가