### PR TITLE
예외 케이스 모두 수정

### DIFF
--- a/backend/src/common/constants/policy-manual-overrides.constant.ts
+++ b/backend/src/common/constants/policy-manual-overrides.constant.ts
@@ -37,37 +37,29 @@ export const POLICY_MANUAL_OVERRIDES: PolicyManualOverride[] = [
     code: 'youth-seoul-한지붕세대공감',
     minAge: null,
     maxAge: null,
+    policyType: PolicyType.INFO,
     disableRule: true,
-    conditionalHints: [
-      '청년(세입자)과 어르신(집주인) 양쪽 모두 신청 가능합니다. 본인 유형에 맞는 조건을 공식 공고문에서 확인하세요.',
-    ],
   },
   {
     code: 'youth-seoul-노장청-쉐어하우스-한지붕세대공감',
     minAge: null,
     maxAge: null,
+    policyType: PolicyType.INFO,
     disableRule: true,
-    conditionalHints: [
-      '청년(세입자)과 어르신(집주인) 양쪽 모두 신청 가능합니다. 본인 유형에 맞는 조건을 공식 공고문에서 확인하세요.',
-    ],
   },
   {
     code: 'youth-seoul-청년과-어르신-주거공유한지붕세대공감',
     minAge: null,
     maxAge: null,
+    policyType: PolicyType.INFO,
     disableRule: true,
-    conditionalHints: [
-      '청년(세입자)과 어르신(집주인) 양쪽 모두 신청 가능합니다. 본인 유형에 맞는 조건을 공식 공고문에서 확인하세요.',
-    ],
   },
   {
     code: 'youthcenter-policy-청년과-어르신-주거공유한지붕세대공감',
     minAge: null,
     maxAge: null,
+    policyType: PolicyType.INFO,
     disableRule: true,
-    conditionalHints: [
-      '청년(세입자)과 어르신(집주인) 양쪽 모두 신청 가능합니다. 본인 유형에 맞는 조건을 공식 공고문에서 확인하세요.',
-    ],
   },
   // 서울시 고립·은둔청년 지원사업 — 제대군인 나이 연장 분기 (base maxAge=39 → 42로 완화)
   {
@@ -114,30 +106,40 @@ export const POLICY_MANUAL_OVERRIDES: PolicyManualOverride[] = [
       name: '청년안심주택 공급활성화(임차보증금 무이자지원) — 소득·자산 기준',
       root: {
         all: [
+          // 신청자 유형 SELECT — requirements 추출 시 SELECT로 잡히도록 top-level에 배치
           {
-            any: [
-              {
-                all: [
-                  { fact: 'answers.applicantType', op: '=', value: '청년', message: '청년 또는 신혼부부만 신청 가능합니다.', verifiable: true },
-                  { fact: 'answers.monthlyIncome', op: '<=', value: 477, message: '청년은 도시근로자 가구당 월평균소득 100% 이하(477만원)여야 합니다.', verifiable: true },
-                  { fact: 'answers.totalAssets', op: '<=', value: 27300, message: '청년은 총 자산 2억 7,300만원 이하여야 합니다.', verifiable: true },
-                ],
-              },
-              {
-                all: [
-                  { fact: 'answers.applicantType', op: '=', value: '신혼부부', message: '청년 또는 신혼부부만 신청 가능합니다.', verifiable: true },
-                  { fact: 'answers.monthlyIncome', op: '<=', value: 572, message: '신혼부부는 도시근로자 가구당 월평균소득 120% 이하(572만원)여야 합니다.', verifiable: true },
-                  { fact: 'answers.totalAssets', op: '<=', value: 34500, message: '신혼부부는 총 자산 3억 4,500만원 이하여야 합니다.', verifiable: true },
-                ],
-              },
-            ],
+            fact: 'answers.applicantType',
+            op: 'in',
+            value: ['청년', '신혼부부'],
+            message: '청년 또는 신혼부부만 신청 가능합니다.',
+            verifiable: true,
           },
+          // 입주 유형 SELECT
           {
             fact: 'answers.housingStatus',
             op: 'in',
             value: ['청년안심주택 입주자', '청년안심주택 입주예정자', '민간임대주택 입주자', '민간임대주택 입주예정자'],
             message: '청년안심주택 또는 민간임대주택 입주(예정)자만 신청 가능합니다.',
             verifiable: true,
+          },
+          // 유형별 소득·자산 분기
+          {
+            any: [
+              {
+                all: [
+                  { fact: 'answers.applicantType', op: '=', value: '청년', verifiable: true },
+                  { fact: 'answers.monthlyIncome', op: '<=', value: 477, message: '청년은 도시근로자 가구당 월평균소득 100% 이하(477만원)여야 합니다.', verifiable: true },
+                  { fact: 'answers.totalAssets', op: '<=', value: 27300, message: '청년은 총 자산 2억 7,300만원 이하여야 합니다.', verifiable: true },
+                ],
+              },
+              {
+                all: [
+                  { fact: 'answers.applicantType', op: '=', value: '신혼부부', verifiable: true },
+                  { fact: 'answers.monthlyIncome', op: '<=', value: 572, message: '신혼부부는 도시근로자 가구당 월평균소득 120% 이하(572만원)여야 합니다.', verifiable: true },
+                  { fact: 'answers.totalAssets', op: '<=', value: 34500, message: '신혼부부는 총 자산 3억 4,500만원 이하여야 합니다.', verifiable: true },
+                ],
+              },
+            ],
           },
         ],
       },
@@ -159,7 +161,7 @@ export const POLICY_MANUAL_OVERRIDES: PolicyManualOverride[] = [
       name: '관악 미취업청년 어학자격시험 응시료 지원 — 중복 혜택 불가 조건',
       root: {
         all: [
-          { fact: 'answers.employmentStatus', op: '=', value: '미취업', message: '미취업 청년만 신청 가능합니다.', verifiable: true },
+          { fact: 'answers.isUnemployed', op: '=', value: true, message: '미취업 청년만 신청 가능합니다.', verifiable: true },
           { fact: 'answers.businessRegistration', op: '=', value: false, message: '사업자 미등록 상태여야 합니다.', verifiable: true },
           { fact: 'answers.qualificationExamTaken', op: '=', value: true, message: '2026년 1월 1일 이후 응시한 어학·자격증 시험이 있어야 합니다.', verifiable: true },
           { fact: 'answers.receivingNationalEmploymentSupport', op: '=', value: false, message: '국민취업지원제도를 지원받고 있는 경우 중복 신청이 불가능합니다.', verifiable: true },
@@ -187,7 +189,7 @@ export const POLICY_MANUAL_OVERRIDES: PolicyManualOverride[] = [
               { fact: 'answers.livingArea', op: '=', value: true, verifiable: true, message: '동대문구 생활권자(직장·학교·활동)여야 합니다.' },
             ],
           },
-          { fact: 'answers.applicantStatus', op: '=', value: '예비창업자', message: '공고일 현재 직장·건강보험 미가입자(예비창업자)만 가능합니다.', verifiable: true },
+          { fact: 'answers.isPreFounder', op: '=', value: true, message: '공고일 현재 직장·건강보험 미가입자(예비창업자)만 가능합니다.', verifiable: true },
           { fact: 'answers.generationalFusion', op: '=', value: true, message: '세대융합형 창업 계획을 가지고 있어야 합니다.', verifiable: true },
         ],
       },
@@ -207,7 +209,7 @@ export const POLICY_MANUAL_OVERRIDES: PolicyManualOverride[] = [
       root: {
         all: [
           { fact: 'answers.employmentStatus', op: 'in', value: ['정규직 재직중', '정규직 신규채용'], message: '동작구 소재 중소기업에 정규직으로 취업해야 합니다.', verifiable: true },
-          { fact: 'answers.companySize', op: '=', value: '중소기업', message: '동작구 소재 중소기업에 근무해야 합니다.', verifiable: true },
+          { fact: 'answers.isSmallCompany', op: '=', value: true, message: '동작구 소재 중소기업에 근무해야 합니다.', verifiable: true },
           { fact: 'answers.receivingSimilarTenureProgram', op: '=', value: false, message: '정부 및 타 지자체 근속장려금 성격의 유사 사업 중복지원은 불가합니다.', verifiable: true },
         ],
       },
@@ -224,7 +226,7 @@ export const POLICY_MANUAL_OVERRIDES: PolicyManualOverride[] = [
         all: [
           { fact: 'answers.applicantType', op: 'in', value: ['예비창업자', '창업자'], message: '예비창업자 또는 창업자만 신청 가능합니다.', verifiable: true },
           { fact: 'answers.yearsAfterFounding', op: '<=', value: 7, message: '창업 7년 이내여야 합니다.', verifiable: true },
-          { fact: 'answers.businessStatus', op: '=', value: '정상 운영 중', message: '휴폐업 중인 자는 신청할 수 없습니다.', verifiable: true },
+          { fact: 'answers.isBusinessActive', op: '=', value: true, message: '휴폐업 중인 자는 신청할 수 없습니다.', verifiable: true },
           { fact: 'answers.taxDelinquency', op: '=', value: false, message: '국세·지방세 체납 기업은 신청할 수 없습니다.', verifiable: true },
           { fact: 'answers.pollutingBusiness', op: '=', value: false, message: '환경관련 법규에 저촉되는 공해 배출업은 신청할 수 없습니다.', verifiable: true },
           { fact: 'answers.prohibitedBusiness', op: '=', value: false, message: '일반유흥주점업, 무도유흥주점업, 사행시설 관리 및 운영업 등 제외 업종은 신청할 수 없습니다.', verifiable: true },
@@ -244,7 +246,7 @@ export const POLICY_MANUAL_OVERRIDES: PolicyManualOverride[] = [
       name: '으뜸관악 청년통장 지원 — 유사자산형성사업 중복 불가 조건',
       root: {
         all: [
-          { fact: 'answers.employmentStatus', op: '=', value: '근로중', message: '근로 청년만 신청 가능합니다.', verifiable: true },
+          { fact: 'answers.isEmployed', op: '=', value: true, message: '근로 청년만 신청 가능합니다.', verifiable: true },
           { fact: 'answers.receivingSimilarAssetProgram', op: '=', value: false, message: '희망두배청년통장, 청년내일저축계좌, 청년내일채움공제 등 유사자산형성사업에 참여 중인 경우 중복 신청이 불가능합니다.', verifiable: true },
         ],
       },
@@ -259,7 +261,7 @@ export const POLICY_MANUAL_OVERRIDES: PolicyManualOverride[] = [
       name: '서리풀 희망사다리 자립정착금 — 서초구 1년 이상 거주',
       root: {
         all: [
-          { fact: 'answers.applicantType', op: '=', value: '자립준비청년(보호종료아동)', message: '자립준비청년(보호종료아동)만 신청 가능합니다.', verifiable: true },
+          { fact: 'answers.isYouthLeavingCare', op: '=', value: true, message: '자립준비청년(보호종료아동)만 신청 가능합니다.', verifiable: true },
           { fact: 'answers.residencyOver1Year', op: '=', value: true, message: '서초구에서 1년 이상 거주 중이어야 합니다.', verifiable: true },
         ],
       },
@@ -326,7 +328,7 @@ export const POLICY_MANUAL_OVERRIDES: PolicyManualOverride[] = [
       root: {
         all: [
           { fact: 'answers.welfareStatus', op: 'in', value: ['기초수급자', '차상위계층', '한부모가족'], message: '기초수급자, 차상위계층, 또는 한부모가족에 해당해야 합니다.', verifiable: true },
-          { fact: 'answers.enrollmentStatus', op: '=', value: '재학 중', message: '대학교에 재학 중이어야 합니다.', verifiable: true },
+          { fact: 'answers.isEnrolled', op: '=', value: true, message: '대학교에 재학 중이어야 합니다.', verifiable: true },
           { fact: 'answers.receivingYouthIndependenceTransport', op: '=', value: false, message: '서울시 자립준비청년 교통비 지원사업을 받고 있는 경우 중복 신청이 불가능합니다.', verifiable: true },
         ],
       },
@@ -373,7 +375,7 @@ export const POLICY_MANUAL_OVERRIDES: PolicyManualOverride[] = [
       name: '청년 국가자격시험 응시료 지원 — 중복 혜택 불가 조건',
       root: {
         all: [
-          { fact: 'answers.employmentStatus', op: '=', value: '미취업', message: '미취업자이면서 사업자등록사실이 없어야 합니다.', verifiable: true },
+          { fact: 'answers.isUnemployed', op: '=', value: true, message: '미취업자이면서 사업자등록사실이 없어야 합니다.', verifiable: true },
           { fact: 'answers.receivingNationalEmploymentSupport', op: '=', value: false, message: '국민취업지원제도를 지원받고 있는 경우 중복 신청이 불가능합니다.', verifiable: true },
           { fact: 'answers.receivingSeoulYouthAllowance', op: '=', value: false, message: '서울 청년수당을 받고 있는 경우 중복 신청이 불가능합니다.', verifiable: true },
         ],
@@ -385,6 +387,51 @@ export const POLICY_MANUAL_OVERRIDES: PolicyManualOverride[] = [
   {
     code: 'data-go-kr-취약계층을-위한-공공일자리-제공',
     regionCodes: [RegionCode.SEOUL],
+  },
+  // 서울시 전세보증금 반환보증 보증료 지원 — 운영기관(마포구청) 주소가 지역으로 잘못 추출됨 + LLM이 소득·보증금을 원 단위로 추출 (만원 단위로 재설정)
+  {
+    code: 'data-go-kr-서울시-전세보증금-반환보증-보증료-지원',
+    regionCodes: [RegionCode.SEOUL],
+    overrideRule: {
+      id: 'manual-전세보증금-반환보증-보증료-income-unit',
+      name: '서울시 전세보증금 반환보증 보증료 지원 — 소득·보증금 만원 단위 수정',
+      root: {
+        all: [
+          // top-level에 배치해야 extractRequirementsFromRuleNode가 SELECT로 추출
+          { fact: 'answers.tenantType', op: 'in', value: ['청년', '신혼부부', '기타'], message: '신청자 유형을 선택해주세요.', verifiable: true },
+          { fact: 'answers.isHomeless', op: '=', value: true, message: '무주택자만 신청 가능합니다.', verifiable: true },
+          { fact: 'answers.depositAmount', op: '<=', value: 30000, message: '임차보증금이 3억원을 초과하였습니다.', verifiable: true },
+          { fact: 'answers.guaranteeAgencyMember', op: '=', value: true, message: '보증기관에 가입한 자만 신청 가능합니다.', verifiable: true },
+          // 유형별 연소득 분기 (만원 단위)
+          {
+            any: [
+              {
+                all: [
+                  { fact: 'answers.tenantType', op: '=', value: '청년', verifiable: true },
+                  { fact: 'answers.annualIncome', op: '<=', value: 5000, message: '청년은 연소득 5천만원 이하여야 합니다.', verifiable: true },
+                ],
+              },
+              {
+                all: [
+                  { fact: 'answers.tenantType', op: '=', value: '신혼부부', verifiable: true },
+                  { fact: 'answers.annualIncome', op: '<=', value: 7500, message: '신혼부부는 연소득 7천5백만원 이하여야 합니다.', verifiable: true },
+                ],
+              },
+              {
+                all: [
+                  { fact: 'answers.tenantType', op: '=', value: '기타', verifiable: true },
+                  { fact: 'answers.annualIncome', op: '<=', value: 6000, message: '기타는 연소득 6천만원 이하여야 합니다.', verifiable: true },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      conditionalHints: [
+        '2025년 3월 31일 이후 보증 가입자는 최대 40만원 지원, 이전 가입자는 최대 30만원 지원됩니다.',
+        '청년외(기타)는 보증료의 90%만 지원됩니다.',
+      ],
+    },
   },
   // 서울시 가족돌봄청년 지원사업 WAY — "자원 안내 및 연결" 표현 때문에 LLM이 info로 오분류 (실제: 별도 공고 통해 생활비·병원비 등 신청형)
   {
@@ -400,6 +447,27 @@ export const POLICY_MANUAL_OVERRIDES: PolicyManualOverride[] = [
     ],
   },
   // 멘토링 지원 — 멘토(성인)와 멘티(청소년) 두 신청층
+  // 성북구 어학·자격증 응시료 — 2026.1.1 이전부터 계속 거주 조건
+  {
+    code: 'youthcenter-policy-미취업-청년-어학-및-자격증-응시료-지원성북구',
+    appendConditionalHints: ['예산 소진 시 조기 종료될 수 있습니다.'],
+    overrideRule: {
+      id: 'manual-성북구-어학자격증-residency',
+      name: '성북구 어학·자격증 응시료 — 계속 거주 조건',
+      root: {
+        all: [
+          {
+            fact: 'answers.continuousResidencySeongbuk',
+            op: '=',
+            value: true,
+            message: '2026.1.1. 이전부터 현재까지 계속하여 성북구에 주민등록상 거주 중이어야 합니다.',
+            verifiable: true,
+          },
+        ],
+      },
+      conditionalHints: [],
+    },
+  },
   {
     code: 'data-go-kr-멘토링-지원',
     minAge: null,

--- a/backend/src/pipeline/llm-rule-extractor.service.ts
+++ b/backend/src/pipeline/llm-rule-extractor.service.ts
@@ -63,7 +63,7 @@ const SYSTEM_PROMPT = `당신은 한국 정부/지자체 정책의 자격 조건
 \`\`\`json
 {
   "key": "영문 camelCase 키 (예: employmentStatus, educationLevel, incomeLevel)",
-  "label": "한국어 라벨 (예: 취업 상태, 학력, 소득 수준)",
+  "label": "한국어 라벨 — 반드시 간결한 명사형으로 작성 (예: 취업 상태, 학력, 소득 수준, 기준 중위소득 150% 이하 해당 여부). 평서문·의문문 금지.",
   "type": "select | number | boolean | string",
   "options": ["선택지1", "선택지2", ...] (type이 select일 때만, 아니면 null),
   "fact": "answers.{key} (예: answers.employmentStatus)",
@@ -85,9 +85,9 @@ const SYSTEM_PROMPT = `당신은 한국 정부/지자체 정책의 자격 조건
 - **소득/자산에 구체적인 금액이 명시된 경우** → \`number\` 타입으로 사용자에게 금액을 직접 입력받으세요.
   - 예: "연소득 5천만원 이하" → type: "number", label: "연소득 (만원)", op: "<=", value: 5000 (만원 단위)
   - 예: "월 소득 300만원 이하" → type: "number", label: "월 소득 (만원)", op: "<=", value: 300
-- **중위소득 기준, 도시근로자 월평균 소득 기준처럼 가구원 수·연도에 따라 금액이 달라지는 경우** → \`boolean\` 타입을 사용하되, label을 질문 형태로 작성하세요.
-  - 예: "중위소득 150% 이하" → type: "boolean", label: "가구 소득이 기준 중위소득 150% 이하인가요?", op: "=", value: true
-  - 예: "도시근로자 월평균 소득 100% 이하" → type: "boolean", label: "가구 소득이 도시근로자 월평균 소득 100% 이하인가요?", op: "=", value: true
+- **중위소득 기준, 도시근로자 월평균 소득 기준처럼 가구원 수·연도에 따라 금액이 달라지는 경우** → \`boolean\` 타입을 사용하되, label은 명사형으로 작성하세요.
+  - 예: "중위소득 150% 이하" → type: "boolean", label: "기준 중위소득 150% 이하 해당 여부", op: "=", value: true
+  - 예: "도시근로자 월평균 소득 100% 이하" → type: "boolean", label: "도시근로자 월평균 소득 100% 이하 해당 여부", op: "=", value: true
 - **소득 기준이 명시됐지만 금액을 특정할 수 없는 경우**: \`boolean\`으로 처리하고 label에 기준을 명시하세요.
 
 ## options 규칙 (매우 중요)

--- a/backend/src/pipeline/policy-requirement-generator.service.ts
+++ b/backend/src/pipeline/policy-requirement-generator.service.ts
@@ -210,15 +210,18 @@ export class PolicyRequirementGeneratorService {
       where: { policyId: policy.id },
     });
     if (existingCount > 0) {
-      // summary가 없으면 LLM summaryOnly 호출 (manual override는 LLM 스킵)
-      if (!isManualOverride && (!policy.shortDescription || policy.shortDescription === policy.description?.slice(0, 120))) {
+      // summary가 없으면 LLM summaryOnly 호출 (manual override도 summary는 생성)
+      if (!policy.shortDescription || policy.shortDescription === policy.description?.slice(0, 120)) {
         const summaryResult = await this.llmExtractor.extractRules(policy, normalized, true);
         if (summaryResult?.summary) {
           policy.shortDescription = summaryResult.summary;
         }
-        // 규칙 기반 INFO는 LLM이 APPLICATION으로 뒤집지 못하게 함 (LLM 비결정성 방지)
-        if (summaryResult?.policyType && !(policy.policyType === PolicyType.INFO && summaryResult.policyType === 'application')) {
+        // manual override의 policyType은 LLM 결과로 덮어쓰지 않음
+        if (!isManualOverride && summaryResult?.policyType && !(policy.policyType === PolicyType.INFO && summaryResult.policyType === 'application')) {
           policy.policyType = summaryResult.policyType === 'info' ? PolicyType.INFO : PolicyType.APPLICATION;
+        }
+        if (manualOverride?.policyType) {
+          policy.policyType = manualOverride.policyType;
         }
         const hasPeriod = policy.isAlwaysOpen || policy.startsAt || policy.endsAt;
         const rawEmpty = !policy.periodRaw || policy.periodRaw.trim() === '-';
@@ -342,10 +345,18 @@ export class PolicyRequirementGeneratorService {
 
     // INFO 타입 정책은 자격 조건 추출 불필요 (summary만 생성)
     const isInfoPolicy = normalized.policyType === PolicyType.INFO;
-    // manual override 정책은 LLM 호출 스킵
+    // manual override 정책은 조건 추출 LLM 스킵, summary는 별도 생성
     const llmResult = isManualOverride
       ? null
       : await this.llmExtractor.extractRules(policy, normalized, isInfoPolicy);
+
+    // manual override 정책: shortDescription이 raw 상태면 summaryOnly로 요약 생성
+    if (isManualOverride && (!policy.shortDescription || policy.shortDescription === policy.description?.slice(0, 120))) {
+      const summaryResult = await this.llmExtractor.extractRules(policy, normalized, true);
+      if (summaryResult?.summary) {
+        policy.shortDescription = summaryResult.summary;
+      }
+    }
 
     if (!isInfoPolicy && !isManualOverride && llmResult && llmResult.conditions.length > 0) {
       // 의미적으로 같은 키 그룹 (LLM이 다른 이름으로 추출할 수 있음)
@@ -507,17 +518,28 @@ export class PolicyRequirementGeneratorService {
       const isNumericComparison =
         typeof node.value === 'number' &&
         ['<=', '>=', '<', '>'].includes(String(node.op));
+      const isInOp = node.op === 'in' && Array.isArray(node.value);
+
+      let type: QuestionType;
+      let options: string[] | null = null;
+      if (typeof node.value === 'boolean') {
+        type = QuestionType.BOOLEAN;
+      } else if (isNumericComparison) {
+        type = QuestionType.NUMBER;
+      } else if (isInOp) {
+        type = QuestionType.SELECT;
+        options = (node.value as unknown[]).filter((v) => typeof v === 'string') as string[];
+      } else {
+        type = QuestionType.STRING;
+      }
+
       reqs.push({
         policyId,
         key,
         label: this.formatKeyAsLabel(key, message),
         description: message,
-        type: typeof node.value === 'boolean'
-          ? QuestionType.BOOLEAN
-          : isNumericComparison
-            ? QuestionType.NUMBER
-            : QuestionType.STRING,
-        options: null,
+        type,
+        options,
         isRequired: true,
         displayOrder: 0,
       });
@@ -555,6 +577,22 @@ export class PolicyRequirementGeneratorService {
       receivingOtherScholarship: '타 장학금 수혜 여부',
       receivingNationalScholarship: '국가장학금 수혜 여부',
       receivingYouthIndependenceTransport: '서울시 자립준비청년 교통비 지원 수혜 여부',
+      previousRecipient: '기선정자 여부 (2023~2025년)',
+      continuousResidencySeongbuk: '성북구 계속 거주 여부 (2026.1.1. 이전부터)',
+      applicantType: '신청자 유형',
+      housingStatus: '입주(예정) 유형',
+      isUnemployed: '미취업 여부',
+      isEmployed: '근로 여부',
+      isYouthLeavingCare: '자립준비청년(보호종료아동) 여부',
+      isEnrolled: '대학교 재학 여부',
+      isPreFounder: '예비창업자 여부',
+      isBusinessActive: '사업체 정상 운영 여부',
+      isSmallCompany: '중소기업 근무 여부',
+      tenantType: '신청자 유형',
+      isHomeless: '무주택자 여부',
+      annualIncome: '연소득 (만원)',
+      depositAmount: '임차보증금 (만원)',
+      guaranteeAgencyMember: '보증기관 가입 여부',
     };
     return LABELS[key] ?? fallback;
   }
@@ -600,10 +638,13 @@ export class PolicyRequirementGeneratorService {
 
   private extractFirstComeHints(extraMeta: Record<string, unknown>): string[] {
     const hints: string[] = [];
-    if (extraMeta?.isFirstComeFirstServed === true) {
+    // youthcenter 소스는 metadata 서브키에 중첩되어 있을 수 있음
+    const meta = (extraMeta?.metadata as Record<string, unknown> | undefined) ?? {};
+    const isFirstCome = extraMeta?.isFirstComeFirstServed === true || meta?.isFirstComeFirstServed === true;
+    if (isFirstCome) {
       hints.push('선착순 접수 정책입니다. 모집 마감 여부를 공식 공고문에서 확인하세요.');
     }
-    const bizPeriodEtc = extraMeta?.bizPeriodEtc;
+    const bizPeriodEtc = (extraMeta?.bizPeriodEtc ?? meta?.bizPeriodEtc) as string | undefined;
     if (typeof bizPeriodEtc === 'string' && bizPeriodEtc.trim() && /소진|마감|종료/.test(bizPeriodEtc)) {
       hints.push(`${bizPeriodEtc.trim()} 조기 종료될 수 있습니다.`);
     }

--- a/backend/src/policies/policies.service.ts
+++ b/backend/src/policies/policies.service.ts
@@ -350,6 +350,7 @@ export class PoliciesService {
         applicationDeadline: (extra.applicationDeadline as string) ?? null,
         warnBox: (extra.warnBox as string) ?? null,
       },
+      policyType: policy.policyType,
       eligibilityCompleteness: this.computeEligibilityCompleteness(policy),
       userState: state?.state ?? null,
       lastEligibility: lastCheck


### PR DESCRIPTION
예외 케이스 모두 수정(주로 자격 판별 옵션 string으로 내려오는 이슈 및 요약 짤림 이슈)
다만 해당 이슈들 모두 LLM과의 연관성이 커서 수정했어도 여전히 재발할 가능성이 높음(프롬프트 위주로 수정을 함)
추가로 관련 사항들

2026년 미취업청년 자격증 응시료 지원사업(중랑구): 1인 생애 10만원 이거는 아마 LLM도 잡기 쉽지 않을뿐더러, 잡아서 자격 판별에 넣는다고 해도, 사용자가 과연 본인이 생애 10만원을 다 썼는지도 모를거고, 어차피 웬만하면 첫 신청자가 대부분일 거라서 괜찮을 듯

요약 잘림의 경우 LLM 일관성 이슈가 있어서, 제시한 것들 중에서 저는 안 짤리는 것들도 있었음

"2026 학자금대출 신용회복(신용유의자 해제) 지원사업" 케이스 보면 사유가 안 뜨는 이슈가 있는데, 사진 보면 일단 자격 판별 옵션 자체가 다르고, 전 사유도 잘 뜹니다. 이것도 LLM 일관성 이슈!

청년 국가자격시험 응시료 지원: 원문에 "영등포구에 1개월 이상 살아야 함"이라는 조건이 있는데 자격 판별에서는 이게 안 들어가고 거주지 확인만 하는 그런 상황이라 예외 케이스에 넣으신거 같은데, 사실 거주지라면 1개월 이상은 무조건 살지 않았을까 라는 생각이 들어서 자격 판별에서 굳이굳이 체크해야 되나 하는 생각도 들었음

맨 마지막 서리풀 시리즈: 저는 전부 신청형으로 판별돼있음... 아마 이것도 LLM 일관성 이슈가 아닐까 싶긴한데, 신청형이 맞지 않나요? 그 원문에서 신청방법 보니까 방문 신청이라고 떠서 신청형 맞는거 같은데