### PR TITLE
[fix] 프론트 인증 플로우 및 계정 UI 개선

### DIFF
--- a/frontend/src/app/api/auth.ts
+++ b/frontend/src/app/api/auth.ts
@@ -1,5 +1,5 @@
 import { apiRequest, setAccessToken, setStoredUserProfile } from './client';
-import type { AuthResponse, LoginRequest, SignupRequest } from '../types/user';
+import type { AuthResponse, CompleteProfileRequest, LoginRequest, SignupRequest } from '../types/user';
 
 export async function signup(payload: SignupRequest) {
   const response = await apiRequest<AuthResponse>('/auth/signup', {
@@ -21,4 +21,23 @@ export async function login(payload: LoginRequest) {
   setAccessToken(response.accessToken);
   setStoredUserProfile(response.user);
   return response;
+}
+
+export async function completeProfile(payload: CompleteProfileRequest) {
+  const response = await apiRequest<AuthResponse>('/auth/complete-profile', {
+    method: 'POST',
+    body: payload,
+    auth: true,
+  });
+
+  setAccessToken(response.accessToken);
+  setStoredUserProfile(response.user);
+  return response;
+}
+
+export async function resendVerification(email: string) {
+  return apiRequest<{ message: string }>('/auth/resend-verification', {
+    method: 'POST',
+    body: { email },
+  });
 }

--- a/frontend/src/app/api/client.ts
+++ b/frontend/src/app/api/client.ts
@@ -82,6 +82,45 @@ export function clearStoredUserProfile() {
   window.localStorage.removeItem(USER_PROFILE_KEY);
 }
 
+export function getEmailVerificationPath(email?: string | null) {
+  const query = email ? `?email=${encodeURIComponent(email)}` : '';
+  return `/check-email${query}`;
+}
+
+export function isEmailVerificationRequiredError(error: unknown) {
+  return (
+    error instanceof ApiClientError &&
+    error.status === 403 &&
+    (error.message.includes('이메일 인증') || error.message === 'Forbidden')
+  );
+}
+
+export function buildOAuthUserProfile(token: string, profileCompleted: boolean): UserProfileSummary | null {
+  try {
+    const [, payload] = token.split('.');
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const decoded = JSON.parse(window.atob(normalized)) as { sub?: string; email?: string };
+
+    if (!decoded.sub || !decoded.email) {
+      return null;
+    }
+
+    return {
+      userId: decoded.sub,
+      email: decoded.email,
+      emailVerified: true,
+      profileCompleted,
+      displayName: null,
+      age: null,
+      gender: null,
+      regionCode: null,
+      interests: [],
+    };
+  } catch {
+    return null;
+  }
+}
+
 export async function apiRequest<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const { method = 'GET', body, headers, query, auth = false, signal } = options;
   const token = auth ? getAccessToken() : null;

--- a/frontend/src/app/api/oauth.ts
+++ b/frontend/src/app/api/oauth.ts
@@ -1,0 +1,5 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:4000';
+
+export function continueWithOAuth(provider: 'google' | 'naver') {
+  window.location.href = `${API_BASE_URL}/auth/${provider}`;
+}

--- a/frontend/src/app/components/RouteErrorFallback.tsx
+++ b/frontend/src/app/components/RouteErrorFallback.tsx
@@ -1,0 +1,39 @@
+import { isRouteErrorResponse, useRouteError } from 'react-router';
+import { AlertCircle } from 'lucide-react';
+import { Button } from './atoms/Button';
+
+export function RouteErrorFallback() {
+  const error = useRouteError();
+  const message = isRouteErrorResponse(error)
+    ? `${error.status} ${error.statusText}`
+    : error instanceof Error
+      ? error.message
+      : '알 수 없는 오류가 발생했습니다.';
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[var(--muted)] px-4">
+      <div className="bg-white rounded-2xl shadow-lg p-8 max-w-md w-full text-center">
+        <div className="flex justify-center mb-4">
+          <div className="p-4 bg-red-100 rounded-full">
+            <AlertCircle className="h-12 w-12 text-red-600" />
+          </div>
+        </div>
+        <h2 className="mb-2">문제가 발생했습니다</h2>
+        <p className="text-[var(--muted-foreground)] mb-6">
+          화면을 불러오는 중 오류가 발생했습니다.
+        </p>
+        <p className="text-sm text-red-600 bg-red-50 rounded-lg p-3 mb-6 font-mono text-left overflow-auto">
+          {message}
+        </p>
+        <div className="flex gap-3">
+          <Button variant="secondary" onClick={() => window.location.reload()} className="flex-1">
+            새로고침
+          </Button>
+          <Button onClick={() => window.location.assign('/')} className="flex-1">
+            홈으로 이동
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/components/molecules/SignupPromptDialog.tsx
+++ b/frontend/src/app/components/molecules/SignupPromptDialog.tsx
@@ -1,0 +1,65 @@
+import { ReactNode } from 'react';
+import { useNavigate } from 'react-router';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '../ui/dialog';
+import googleLogo from '../../../img/google-logo.svg';
+import naverLogo from '../../../img/naver-logo.svg';
+import { continueWithOAuth } from '../../api/oauth';
+
+interface SignupPromptDialogProps {
+  children: ReactNode;
+}
+
+export function SignupPromptDialog({ children }: SignupPromptDialogProps) {
+  const navigate = useNavigate();
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="w-[min(calc(100vw-2rem),340px)] gap-3 border border-[var(--border)] bg-white p-5 shadow-2xl sm:p-6">
+        <DialogHeader className="pr-6 text-left">
+          <DialogTitle className="text-lg font-bold text-[var(--foreground)]">
+            가입 방식 선택
+          </DialogTitle>
+          <DialogDescription className="text-xs leading-relaxed text-[var(--muted-foreground)]">
+            기존 회원가입 또는 소셜 계정으로 빠르게 시작하세요.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="mt-1 space-y-2.5">
+          <button
+            type="button"
+            onClick={() => navigate('/signup')}
+            className="flex h-11 w-full items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--secondary)] text-sm font-semibold text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]"
+          >
+            회원가입하기
+          </button>
+
+          <button
+            type="button"
+            onClick={() => continueWithOAuth('google')}
+            className="relative flex h-11 w-full items-center justify-center rounded-lg border border-[var(--border)] bg-white text-sm font-semibold text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]"
+          >
+            <img src={googleLogo} alt="" className="absolute left-4 h-4.5 w-4.5" aria-hidden="true" />
+            구글로 가입
+          </button>
+
+          <button
+            type="button"
+            onClick={() => continueWithOAuth('naver')}
+            className="relative flex h-11 w-full items-center justify-center rounded-lg border border-[#03c75a] bg-white text-sm font-semibold text-[#03c75a] transition-colors hover:bg-green-50"
+          >
+            <img src={naverLogo} alt="" className="absolute left-4 h-4.5 w-4.5" aria-hidden="true" />
+            네이버로 가입
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/components/organisms/Header.tsx
+++ b/frontend/src/app/components/organisms/Header.tsx
@@ -1,14 +1,22 @@
-import { Link, useLocation, useNavigate } from 'react-router';
-import { ArrowRight, User, LogOut } from 'lucide-react';
+import { Link, useLocation } from 'react-router';
+import { ArrowRight, User, LogOut, ChevronDown, LockKeyhole, ShieldAlert } from 'lucide-react';
 import { Button } from '../atoms/Button';
 import { useState, useEffect } from 'react';
 import { cn } from '../../lib/utils';
 import { NotificationButton } from '../molecules/NotificationButton';
+import { SignupPromptDialog } from '../molecules/SignupPromptDialog';
 import { getAccessToken, getStoredUserProfile, clearAccessToken, clearStoredUserProfile } from '../../api/client';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
 
 export function Header() {
   const location = useLocation();
-  const navigate = useNavigate();
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [userName, setUserName] = useState<string | null>(null);
 
@@ -24,7 +32,6 @@ export function Header() {
     clearStoredUserProfile();
     setIsAuthenticated(false);
     setUserName(null);
-    navigate('/login');
   };
 
   const isActive = (path: string) => location.pathname === path;
@@ -104,16 +111,45 @@ export function Header() {
             </div>
           )}
           {isAuthenticated ? (
-            <>
-              <Link to="/profile" className="hidden sm:flex items-center gap-1.5 text-sm font-medium text-[var(--foreground)] hover:text-[var(--accent)] transition-colors">
-                <User className="h-4 w-4" aria-hidden="true" />
-                {userName}
-              </Link>
-              <Button variant="ghost" size="sm" className="hidden sm:flex gap-1.5" onClick={handleLogout}>
-                <LogOut className="h-4 w-4" aria-hidden="true" />
-                로그아웃
-              </Button>
-            </>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="hidden sm:flex h-9 items-center gap-1.5 rounded-xl px-3 text-sm font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/30"
+                >
+                  <User className="h-4 w-4" aria-hidden="true" />
+                  <span className="max-w-28 truncate">{userName}</span>
+                  <ChevronDown className="h-3.5 w-3.5 text-[var(--muted-foreground)]" aria-hidden="true" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" sideOffset={10} className="w-48 rounded-xl p-1.5 shadow-xl">
+                <DropdownMenuLabel className="px-3 py-2">
+                  <p className="truncate text-sm font-semibold text-[var(--foreground)]">{userName}</p>
+                  <p className="text-xs font-normal text-[var(--muted-foreground)]">계정 메뉴</p>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild className="cursor-pointer rounded-lg px-3 py-2.5">
+                  <Link to="/profile?tab=password">
+                    <LockKeyhole className="h-4 w-4" aria-hidden="true" />
+                    비밀번호 변경
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild className="cursor-pointer rounded-lg px-3 py-2.5">
+                  <Link to="/profile?tab=withdraw">
+                    <ShieldAlert className="h-4 w-4" aria-hidden="true" />
+                    회원탈퇴
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  className="cursor-pointer rounded-lg px-3 py-2.5 text-red-600 focus:bg-red-50 focus:text-red-600"
+                  onSelect={handleLogout}
+                >
+                  <LogOut className="h-4 w-4" aria-hidden="true" />
+                  로그아웃
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           ) : (
             <>
               <Link to="/login" className="hidden sm:block">
@@ -122,9 +158,11 @@ export function Header() {
                   로그인
                 </Button>
               </Link>
-              <Link to="/signup" className="hidden sm:block">
-                <Button size="sm">회원가입</Button>
-              </Link>
+              <div className="hidden sm:block">
+                <SignupPromptDialog>
+                  <Button size="sm">회원가입</Button>
+                </SignupPromptDialog>
+              </div>
             </>
           )}
           

--- a/frontend/src/app/components/organisms/PolicyCard.tsx
+++ b/frontend/src/app/components/organisms/PolicyCard.tsx
@@ -223,7 +223,7 @@ export function PolicyCard({
         className={cn(
           'group relative border rounded-3xl p-6 sm:p-8 h-full flex flex-col',
           'shadow-sm hover:shadow-xl',
-          status ? borderColors[status] : periodRaw ? 'border-amber-500 hover:border-amber-600 hover:shadow-amber-500/25 bg-amber-50/40' : 'border-red-500 hover:border-red-600 hover:shadow-red-500/30 bg-red-100/70',
+          status ? borderColors[status] : periodRaw ? 'border-[#00D9D9] hover:border-[#00BDBD] hover:shadow-[#00FFFF]/25 bg-[#00FFFF]/10' : 'border-amber-500 hover:border-amber-600 hover:shadow-amber-500/25 bg-amber-50/60',
           urgentDeadlineLabel && 'border-red-500 hover:border-red-600',
           'hover:-translate-y-2',
           'transition-all duration-300 ease-out',
@@ -279,7 +279,7 @@ export function PolicyCard({
           <PolicyMetaRow
             region={formatRegionCodes(regionCodes)}
             period={formatPolicyPeriod(startsAt, endsAt, isAlwaysOpen, periodRaw)}
-            periodClassName={!isAlwaysOpen && !(startsAt && endsAt) ? 'text-red-500' : undefined}
+            periodClassName={!isAlwaysOpen && !(startsAt && endsAt) ? periodRaw ? 'text-[#007A7A]' : 'text-amber-600' : undefined}
           />
           <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-all duration-200 flex-shrink-0" aria-hidden="true">
             <span className="text-xs font-medium text-[var(--accent)]">자세히</span>

--- a/frontend/src/app/pages/CheckEmailPage.tsx
+++ b/frontend/src/app/pages/CheckEmailPage.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router';
+import { ArrowRight, MailCheck } from 'lucide-react';
+import { toast } from 'sonner';
+import { resendVerification } from '../api/auth';
+import { ApiClientError, getStoredUserProfile } from '../api/client';
+import { Button } from '../components/atoms/Button';
+
+export function CheckEmailPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const storedUser = getStoredUserProfile();
+  const email = searchParams.get('email') ?? storedUser?.email ?? '';
+  const [loading, setLoading] = useState(false);
+
+  const handleResend = async () => {
+    if (!email) {
+      toast.error('이메일 정보가 없습니다. 다시 회원가입 또는 로그인해주세요.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await resendVerification(email);
+      toast.success('인증 메일을 다시 보냈습니다.');
+    } catch (error) {
+      const message = error instanceof ApiClientError ? error.message : '인증 메일 재발송에 실패했습니다.';
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center px-4 py-8 sm:py-12">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-6 sm:mb-8">
+          <Link to="/" className="inline-flex items-center gap-2.5 sm:gap-3 mb-4 hover:opacity-80 transition-opacity">
+            <div className="relative">
+              <div className="flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 bg-gradient-to-br from-blue-600 to-purple-600 rounded-xl shadow-lg shadow-blue-500/30">
+                <ArrowRight className="h-5 w-5 sm:h-6 sm:w-6 text-white" strokeWidth={2.5} aria-hidden="true" />
+              </div>
+              <div className="absolute -top-1 -right-1 w-3.5 h-3.5 sm:w-4 sm:h-4 bg-gradient-to-br from-amber-400 to-orange-500 rounded-full"></div>
+            </div>
+            <div className="flex flex-col items-start">
+              <span className="text-xl sm:text-2xl font-bold tracking-tight bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent leading-none">bengo</span>
+              <span className="text-[10px] sm:text-xs text-[var(--muted-foreground)] tracking-wide leading-none mt-0.5 sm:mt-1">benefit + go</span>
+            </div>
+          </Link>
+        </div>
+
+        <div className="bg-white rounded-2xl shadow-lg p-8 text-center">
+          <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-50 text-[var(--accent)]">
+            <MailCheck className="h-7 w-7" aria-hidden="true" />
+          </div>
+          <h1 className="text-xl font-bold text-[var(--foreground)]">인증 메일을 확인해주세요</h1>
+          <p className="mt-3 text-sm leading-relaxed text-[var(--muted-foreground)]">
+            {email ? <><span className="font-medium text-[var(--foreground)]">{email}</span>로 인증 링크를 보냈습니다.</> : '가입한 이메일로 인증 링크를 보냈습니다.'}
+            <br />
+            링크를 눌러야 자격확인, 정책 저장, MY 기능을 이용할 수 있어요.
+          </p>
+
+          <div className="mt-7 space-y-3">
+            <Button type="button" className="w-full" onClick={() => navigate('/login')}>
+              로그인하러 가기
+            </Button>
+            <Button type="button" variant="secondary" className="w-full" loading={loading} onClick={handleResend}>
+              인증 메일 재발송
+            </Button>
+            <Link to="/policies" className="block text-sm text-[var(--muted-foreground)] hover:text-[var(--accent)]">
+              가입 없이 정책 둘러보기
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CheckEmailPage;

--- a/frontend/src/app/pages/EmailVerifiedPage.tsx
+++ b/frontend/src/app/pages/EmailVerifiedPage.tsx
@@ -1,0 +1,87 @@
+import { useEffect } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router';
+import { ArrowRight, CheckCircle2, CircleAlert, Clock } from 'lucide-react';
+import { Button } from '../components/atoms/Button';
+
+const statusContent = {
+  success: {
+    icon: CheckCircle2,
+    title: '이메일 인증이 완료되었습니다',
+    description: '잠시 후 로그인 페이지로 이동합니다.',
+    tone: 'text-emerald-600 bg-emerald-50',
+  },
+  expired: {
+    icon: Clock,
+    title: '인증 링크가 만료되었습니다',
+    description: '로그인 후 인증 메일을 다시 요청해주세요.',
+    tone: 'text-amber-600 bg-amber-50',
+  },
+  invalid: {
+    icon: CircleAlert,
+    title: '유효하지 않은 인증 링크입니다',
+    description: '링크가 잘못되었거나 이미 사용된 링크일 수 있어요.',
+    tone: 'text-red-600 bg-red-50',
+  },
+};
+
+export function EmailVerifiedPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const rawStatus = searchParams.get('status') ?? 'invalid';
+  const status = rawStatus in statusContent ? rawStatus as keyof typeof statusContent : 'invalid';
+  const content = statusContent[status];
+  const Icon = content.icon;
+
+  useEffect(() => {
+    if (status !== 'success') {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      navigate('/login', { replace: true });
+    }, 1200);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [navigate, status]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center px-4 py-8 sm:py-12">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-6 sm:mb-8">
+          <Link to="/" className="inline-flex items-center gap-2.5 sm:gap-3 mb-4 hover:opacity-80 transition-opacity">
+            <div className="relative">
+              <div className="flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 bg-gradient-to-br from-blue-600 to-purple-600 rounded-xl shadow-lg shadow-blue-500/30">
+                <ArrowRight className="h-5 w-5 sm:h-6 sm:w-6 text-white" strokeWidth={2.5} aria-hidden="true" />
+              </div>
+              <div className="absolute -top-1 -right-1 w-3.5 h-3.5 sm:w-4 sm:h-4 bg-gradient-to-br from-amber-400 to-orange-500 rounded-full"></div>
+            </div>
+            <div className="flex flex-col items-start">
+              <span className="text-xl sm:text-2xl font-bold tracking-tight bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent leading-none">bengo</span>
+              <span className="text-[10px] sm:text-xs text-[var(--muted-foreground)] tracking-wide leading-none mt-0.5 sm:mt-1">benefit + go</span>
+            </div>
+          </Link>
+        </div>
+
+        <div className="bg-white rounded-2xl shadow-lg p-8 text-center">
+          <div className={`mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl ${content.tone}`}>
+            <Icon className="h-7 w-7" aria-hidden="true" />
+          </div>
+          <h1 className="text-xl font-bold text-[var(--foreground)]">{content.title}</h1>
+          <p className="mt-3 text-sm leading-relaxed text-[var(--muted-foreground)]">{content.description}</p>
+          <div className="mt-7 space-y-3">
+            <Link to="/login" className="block">
+              <Button type="button" className="w-full">
+                로그인하기
+              </Button>
+            </Link>
+            <Link to="/policies" className="block text-sm text-[var(--muted-foreground)] hover:text-[var(--accent)]">
+              정책 먼저 둘러보기
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default EmailVerifiedPage;

--- a/frontend/src/app/pages/HomePage.tsx
+++ b/frontend/src/app/pages/HomePage.tsx
@@ -6,6 +6,7 @@ import { motion } from 'motion/react';
 import { useRef } from 'react';
 import { Summary } from '../components/organisms/Summary';
 import { FAQ } from '../components/organisms/FAQ';
+import { SignupPromptDialog } from '../components/molecules/SignupPromptDialog';
 
 export function HomePage() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -239,9 +240,9 @@ export function HomePage() {
                           <span className="w-1.5 h-1.5 rounded-full bg-blue-500"></span>
                           상시 4
                         </div>
-                        <div className="flex items-center gap-1 text-[10px] font-semibold text-amber-700 bg-amber-50 border border-amber-200 px-1.5 py-0.5 rounded-full">
-                          <span className="w-1.5 h-1.5 rounded-full bg-amber-500"></span>
-                          별도 확인 2
+                        <div className="flex items-center gap-1 text-[10px] font-semibold text-[#007A7A] bg-[#00FFFF]/10 border border-[#00D9D9]/60 px-1.5 py-0.5 rounded-full">
+                          <span className="w-1.5 h-1.5 rounded-full bg-[#00D9D9]"></span>
+                          정책별 확인 2
                         </div>
                       </div>
                     </div>
@@ -654,11 +655,14 @@ export function HomePage() {
               회원가입하고 나에게 딱 맞는<br className="sm:hidden" /> 정책을 추천받아보세요
             </p>
             <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
-              <Link to="/signup">
-                <Button size="lg" className="w-full sm:w-auto min-w-[180px]">
+              <SignupPromptDialog>
+                <button
+                  type="button"
+                  className="inline-flex h-12 w-full min-w-[180px] items-center justify-center gap-2 rounded-xl bg-[var(--accent)] px-7 py-3.5 text-base font-medium text-[var(--accent-foreground)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-blue-500/25 active:scale-[0.97] sm:w-auto"
+                >
                   무료로 시작하기
-                </Button>
-              </Link>
+                </button>
+              </SignupPromptDialog>
               <Link to="/policies">
                 <Button size="lg" variant="secondary" className="w-full sm:w-auto min-w-[180px]">
                   정책 먼저 둘러보기

--- a/frontend/src/app/pages/LoginPage.tsx
+++ b/frontend/src/app/pages/LoginPage.tsx
@@ -2,8 +2,9 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { ArrowRight } from 'lucide-react';
 import { toast } from 'sonner';
-import { ApiClientError } from '../api/client';
+import { ApiClientError, getEmailVerificationPath } from '../api/client';
 import { login } from '../api/auth';
+import { continueWithOAuth } from '../api/oauth';
 import { Button } from '../components/atoms/Button';
 import { Input } from '../components/atoms/Input';
 import googleLogo from '../../img/google-logo.svg';
@@ -41,12 +42,16 @@ export function LoginPage() {
     if (validate()) {
       setLoading(true);
       try {
-        await login({
+        const response = await login({
           email: formData.email,
           password: formData.password,
         });
         toast.success('로그인 성공!');
-        navigate('/policies');
+        if (!response.user.emailVerified) {
+          navigate(getEmailVerificationPath(response.user.email));
+          return;
+        }
+        navigate(response.user.profileCompleted ? '/policies' : '/onboarding');
       } catch (error) {
         const message = error instanceof ApiClientError ? error.message : '로그인에 실패했습니다';
         toast.error(message);
@@ -66,7 +71,7 @@ export function LoginPage() {
       <div className="w-full max-w-md">
         {/* Logo */}
         <div className="text-center mb-6 sm:mb-8">
-          <Link to="/" className="inline-flex items-center gap-2.5 sm:gap-3 mb-4 hover:opacity-80 transition-opacity">
+          <a href="/" className="inline-flex items-center gap-2.5 sm:gap-3 mb-4 hover:opacity-80 transition-opacity">
             <div className="relative">
               <div className="flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 bg-gradient-to-br from-blue-600 to-purple-600 rounded-xl shadow-lg shadow-blue-500/30">
                 <ArrowRight className="h-5 w-5 sm:h-6 sm:w-6 text-white" strokeWidth={2.5} aria-hidden="true" />
@@ -77,7 +82,7 @@ export function LoginPage() {
               <span className="text-xl sm:text-2xl font-bold tracking-tight bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent leading-none">bengo</span>
               <span className="text-[10px] sm:text-xs text-[var(--muted-foreground)] tracking-wide leading-none mt-0.5 sm:mt-1">benefit + go</span>
             </div>
-          </Link>
+          </a>
           <p className="text-sm sm:text-base text-[var(--muted-foreground)]">정책 혜택을 찾아드립니다</p>
         </div>
 
@@ -138,6 +143,7 @@ export function LoginPage() {
           <div className="mt-4 space-y-2">
             <button
               type="button"
+              onClick={() => continueWithOAuth('google')}
               className="relative flex w-full items-center justify-center rounded-xl border border-[var(--border)] bg-white p-3 text-sm font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)] cursor-pointer"
             >
               <img src={googleLogo} alt="" className="absolute left-4 h-5 w-5" aria-hidden="true" />
@@ -145,6 +151,7 @@ export function LoginPage() {
             </button>
             <button
               type="button"
+              onClick={() => continueWithOAuth('naver')}
               className="relative flex w-full items-center justify-center rounded-xl border border-[#03C75A] bg-white p-3 text-sm font-semibold text-[#03C75A] transition-colors hover:bg-green-50 cursor-pointer"
             >
               <img src={naverLogo} alt="" className="absolute left-4 h-5 w-5" aria-hidden="true" />

--- a/frontend/src/app/pages/MyPage.tsx
+++ b/frontend/src/app/pages/MyPage.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import { User, MapPin, Sparkles, Edit, Trash2, X } from 'lucide-react';
-import { Link, useSearchParams } from 'react-router';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 import { getPolicyDetail } from '../api/policies';
-import { ApiClientError, getStoredUserProfile, setStoredUserProfile } from '../api/client';
+import { ApiClientError, getEmailVerificationPath, getStoredUserProfile, isEmailVerificationRequiredError, setStoredUserProfile } from '../api/client';
 import { getMyPolicies, removeMyPolicy } from '../api/me';
 import { MainLayout } from '../components/templates/MainLayout';
 import { Button } from '../components/atoms/Button';
@@ -23,7 +23,7 @@ type SavedPolicy = PolicyCardProps & {
 
 interface UserProfileView {
   name: string;
-  age: number;
+  age: number | null;
   region: string;
   interests: string[];
 }
@@ -108,6 +108,7 @@ function mapStoredUserToView(user: UserProfileSummary | null): UserProfileView |
 const PAGE_SIZE = 12;
 
 export function MyPage() {
+  const navigate = useNavigate();
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = Math.max(1, Number(searchParams.get('page') ?? '1'));
@@ -123,7 +124,7 @@ export function MyPage() {
   const [editForm, setEditForm] = useState<EditFormState>(() => {
     const stored = getStoredUserProfile();
     return {
-      age: stored ? String(stored.age) : '',
+      age: stored?.age ? String(stored.age) : '',
       regionCode: stored?.regionCode ?? '',
       interests: stored?.interests ?? [],
     };
@@ -139,6 +140,16 @@ export function MyPage() {
       setHasError(false);
 
       const storedUser = getStoredUserProfile();
+      if (storedUser && !storedUser.emailVerified) {
+        navigate(getEmailVerificationPath(storedUser.email), { replace: true });
+        return;
+      }
+
+      if (storedUser && !storedUser.profileCompleted) {
+        navigate('/onboarding', { replace: true });
+        return;
+      }
+
       setUser(mapStoredUserToView(storedUser));
 
       try {
@@ -156,6 +167,11 @@ export function MyPage() {
 
         setSavedPolicies(details);
       } catch (error) {
+        if (isEmailVerificationRequiredError(error)) {
+          const email = getStoredUserProfile()?.email;
+          navigate(getEmailVerificationPath(email), { replace: true });
+          return;
+        }
         setHasError(true);
         const message = error instanceof ApiClientError ? error.message : '내 정책 정보를 불러오는데 실패했습니다';
         toast.error(message);
@@ -165,7 +181,7 @@ export function MyPage() {
     };
 
     loadMyPolicies();
-  }, [reloadKey]);
+  }, [navigate, reloadKey]);
 
   const handleDelete = async (id: string) => {
     try {
@@ -173,6 +189,11 @@ export function MyPage() {
       setSavedPolicies((current) => current.filter((policy) => policy.id !== id));
       toast.success('정책이 저장 목록에서 삭제되었습니다');
     } catch (error) {
+      if (isEmailVerificationRequiredError(error)) {
+        const email = getStoredUserProfile()?.email;
+        navigate(getEmailVerificationPath(email));
+        return;
+      }
       const message = error instanceof ApiClientError ? error.message : '정책 삭제에 실패했습니다';
       toast.error(message);
     }
@@ -206,6 +227,7 @@ export function MyPage() {
       age: editForm.age ? Number(editForm.age) : storedUser.age,
       regionCode: (editForm.regionCode || storedUser.regionCode) as typeof storedUser.regionCode,
       interests: editForm.interests.length > 0 ? editForm.interests as typeof storedUser.interests : storedUser.interests,
+      profileCompleted: true,
     };
 
     setStoredUserProfile(nextStoredUser);
@@ -244,7 +266,7 @@ export function MyPage() {
                   <div className="flex flex-wrap gap-3 text-sm text-[var(--muted-foreground)]">
                     <div className="flex items-center gap-1.5">
                       <Sparkles className="h-4 w-4 flex-shrink-0" />
-                      <span>{user ? `${user.age}세` : '나이 정보 없음'}</span>
+                      <span>{user?.age ? `${user.age}세` : '나이 정보 없음'}</span>
                     </div>
                     <div className="flex items-center gap-1.5">
                       <MapPin className="h-4 w-4 flex-shrink-0" />

--- a/frontend/src/app/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/app/pages/OAuthCallbackPage.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  buildOAuthUserProfile,
+  setAccessToken,
+  setStoredUserProfile,
+} from '../api/client';
+
+export function OAuthCallbackPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const token = searchParams.get('token');
+    const profileCompleted = searchParams.get('profileCompleted') === 'true';
+
+    if (!token) {
+      toast.error('OAuth 로그인 정보를 받지 못했습니다.');
+      navigate('/login', { replace: true });
+      return;
+    }
+
+    const profile = buildOAuthUserProfile(token, profileCompleted);
+    if (!profile) {
+      toast.error('OAuth 로그인 정보를 확인하지 못했습니다.');
+      navigate('/login', { replace: true });
+      return;
+    }
+
+    setAccessToken(token);
+    setStoredUserProfile(profile);
+
+    if (!profileCompleted) {
+      navigate('/onboarding', { replace: true });
+      return;
+    }
+
+    toast.success('로그인되었습니다.');
+    navigate('/policies', { replace: true });
+  }, [navigate, searchParams]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center px-4">
+      <div className="flex flex-col items-center gap-4 rounded-2xl bg-white px-8 py-10 shadow-lg">
+        <Loader2 className="h-7 w-7 animate-spin text-[var(--accent)]" aria-hidden="true" />
+        <p className="text-sm font-medium text-[var(--foreground)]">로그인 정보를 확인하고 있어요</p>
+      </div>
+    </div>
+  );
+}
+
+export default OAuthCallbackPage;

--- a/frontend/src/app/pages/OnboardingPage.tsx
+++ b/frontend/src/app/pages/OnboardingPage.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { ArrowRight } from 'lucide-react';
+import { toast } from 'sonner';
+import { completeProfile } from '../api/auth';
+import { ApiClientError, getAccessToken, getStoredUserProfile } from '../api/client';
+import { Button } from '../components/atoms/Button';
+import { Chip } from '../components/atoms/Chip';
+import { Input } from '../components/atoms/Input';
+import { REGION_OPTIONS } from '../lib/regions';
+import type { Gender, InterestCategory, RegionCode } from '../types';
+
+const CURRENT_YEAR = 2026;
+
+const interestOptions: Array<{ value: InterestCategory; label: string; enabled: boolean }> = [
+  { value: 'youth_policy', label: '청년정책', enabled: true },
+  { value: 'childcare_policy', label: '육아정책 (추후 제공)', enabled: false },
+];
+
+export function OnboardingPage() {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    birthYear: '',
+    gender: 'unspecified' as Gender,
+    regionCode: 'seoul' as RegionCode,
+    interests: ['youth_policy'] as InterestCategory[],
+  });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    const token = getAccessToken();
+    const user = getStoredUserProfile();
+
+    if (!token || !user) {
+      navigate('/login', { replace: true });
+      return;
+    }
+
+    if (user.profileCompleted) {
+      navigate('/policies', { replace: true });
+    }
+  }, [navigate]);
+
+  const validate = () => {
+    const nextErrors: Record<string, string> = {};
+    const birthYear = Number(formData.birthYear);
+
+    if (!formData.birthYear) {
+      nextErrors.birthYear = '출생연도를 입력해주세요';
+    } else if (!Number.isInteger(birthYear) || birthYear < 1900 || birthYear > CURRENT_YEAR) {
+      nextErrors.birthYear = '올바른 출생연도를 입력해주세요';
+    }
+
+    if (!formData.regionCode) {
+      nextErrors.regionCode = '거주 지역을 선택해주세요';
+    }
+
+    if (formData.interests.length === 0) {
+      nextErrors.interests = '관심 분야를 1개 이상 선택해주세요';
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!validate()) {
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const birthYear = Number(formData.birthYear);
+      await completeProfile({
+        age: Math.max(0, CURRENT_YEAR - birthYear),
+        gender: formData.gender,
+        regionCode: formData.regionCode,
+        interests: formData.interests,
+      });
+
+      toast.success('프로필이 완성되었습니다.');
+      navigate('/policies', { replace: true });
+    } catch (error) {
+      const message = error instanceof ApiClientError ? error.message : '프로필 저장에 실패했습니다.';
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center px-4 py-8 sm:py-12">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-6 sm:mb-8">
+          <Link to="/" className="inline-flex items-center gap-2.5 sm:gap-3 mb-4 hover:opacity-80 transition-opacity">
+            <div className="relative">
+              <div className="flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 bg-gradient-to-br from-blue-600 to-purple-600 rounded-xl shadow-lg shadow-blue-500/30">
+                <ArrowRight className="h-5 w-5 sm:h-6 sm:w-6 text-white" strokeWidth={2.5} aria-hidden="true" />
+              </div>
+              <div className="absolute -top-1 -right-1 w-3.5 h-3.5 sm:w-4 sm:h-4 bg-gradient-to-br from-amber-400 to-orange-500 rounded-full"></div>
+            </div>
+            <div className="flex flex-col items-start">
+              <span className="text-xl sm:text-2xl font-bold tracking-tight bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent leading-none">bengo</span>
+              <span className="text-[10px] sm:text-xs text-[var(--muted-foreground)] tracking-wide leading-none mt-0.5 sm:mt-1">benefit + go</span>
+            </div>
+          </Link>
+          <p className="text-sm sm:text-base text-[var(--muted-foreground)]">맞춤 추천에 필요한 정보를 조금만 더 알려주세요</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="bg-white rounded-2xl shadow-lg p-8 space-y-5">
+          <div>
+            <label className="block mb-2">출생연도</label>
+            <Input
+              type="number"
+              placeholder="예: 1995"
+              value={formData.birthYear}
+              onChange={(event) => setFormData({ ...formData, birthYear: event.target.value })}
+              error={errors.birthYear}
+            />
+          </div>
+
+          <div>
+            <label className="block mb-2">성별</label>
+            <div className="grid grid-cols-4 gap-2">
+              {[
+                ['male', '남성'],
+                ['female', '여성'],
+                ['other', '기타'],
+                ['unspecified', '선택 안 함'],
+              ].map(([value, label]) => (
+                <Chip
+                  key={value}
+                  selected={formData.gender === value}
+                  onClick={() => setFormData({ ...formData, gender: value as Gender })}
+                  className="px-2 text-xs"
+                >
+                  {label}
+                </Chip>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="block mb-2">거주 지역</label>
+            <select
+              value={formData.regionCode}
+              onChange={(event) => setFormData({ ...formData, regionCode: event.target.value as RegionCode })}
+              className="h-11 w-full rounded-xl border border-[var(--border)] bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/30"
+            >
+              {REGION_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            {errors.regionCode && <p className="mt-1 text-sm text-red-500">{errors.regionCode}</p>}
+          </div>
+
+          <div>
+            <label className="block mb-3">관심 분야</label>
+            <div className="space-y-2">
+              {interestOptions.map((interest) => {
+                const selected = formData.interests.includes(interest.value);
+                return (
+                  <button
+                    key={interest.value}
+                    type="button"
+                    disabled={!interest.enabled}
+                    onClick={() => {
+                      if (!interest.enabled) return;
+                      setFormData({
+                        ...formData,
+                        interests: selected
+                          ? formData.interests.filter((item) => item !== interest.value)
+                          : [...formData.interests, interest.value],
+                      });
+                    }}
+                    className={`w-full rounded-xl border p-4 text-left transition-colors ${
+                      selected
+                        ? 'border-[var(--accent)] bg-blue-50'
+                        : 'border-[var(--border)] hover:bg-[var(--muted)]'
+                    } ${!interest.enabled ? 'cursor-not-allowed opacity-50' : ''}`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium">{interest.label}</span>
+                      {!interest.enabled && <span className="text-xs text-[var(--muted-foreground)]">추후 제공</span>}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+            {errors.interests && <p className="mt-1 text-sm text-red-500">{errors.interests}</p>}
+          </div>
+
+          <Button type="submit" loading={loading} className="w-full">
+            맞춤 정책 추천 받기
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default OnboardingPage;

--- a/frontend/src/app/pages/PersonalizedPoliciesPage.tsx
+++ b/frontend/src/app/pages/PersonalizedPoliciesPage.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react';
-import { Link, useSearchParams } from 'react-router';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 import { ArrowRight, MapPin, User as UserIcon, LogIn, Gift } from 'lucide-react';
 import { toast } from 'sonner';
 import { getPoliciesRecommended } from '../api/policies';
-import { ApiClientError, getAccessToken, getStoredUserProfile, setStoredUserProfile } from '../api/client';
+import { ApiClientError, getAccessToken, getEmailVerificationPath, getStoredUserProfile, setStoredUserProfile } from '../api/client';
 import { MainLayout } from '../components/templates/MainLayout';
 import { PolicyList } from '../components/organisms/PolicyList';
 import { PolicyCardSkeleton } from '../components/molecules/PolicyCardSkeleton';
 import { EmptyState } from '../components/molecules/EmptyState';
+import { SignupPromptDialog } from '../components/molecules/SignupPromptDialog';
 import { Button } from '../components/atoms/Button';
 import { MatchSummaryCard } from '../components/organisms/MatchSummaryCard';
 import type { PolicyListItem } from '../types';
@@ -16,6 +17,7 @@ import { formatRegionCode, REGION_CODE_BY_LABEL } from '../lib/regions';
 const PAGE_SIZE = 12;
 
 export function PersonalizedPoliciesPage() {
+  const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
   const [personalizedPolicies, setPersonalizedPolicies] = useState<PolicyListItem[]>([]);
@@ -37,6 +39,16 @@ export function PersonalizedPoliciesPage() {
 
       if (!currentUser) {
         setIsLoading(false);
+        return;
+      }
+
+      if (!currentUser.emailVerified) {
+        navigate(getEmailVerificationPath(currentUser.email), { replace: true });
+        return;
+      }
+
+      if (!currentUser.profileCompleted) {
+        navigate('/onboarding', { replace: true });
         return;
       }
 
@@ -63,7 +75,7 @@ export function PersonalizedPoliciesPage() {
 
     void loadPersonalizedPolicies();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reloadKey]);
+  }, [navigate, reloadKey]);
 
   const handleRetry = () => {
     setReloadKey((current) => current + 1);
@@ -123,11 +135,13 @@ export function PersonalizedPoliciesPage() {
                     로그인하고 시작하기
                   </Button>
                 </Link>
-                <Link to="/signup" className="flex-1">
-                  <Button variant="secondary" className="w-full">
-                    회원가입
-                  </Button>
-                </Link>
+                <div className="flex-1">
+                  <SignupPromptDialog>
+                    <Button variant="secondary" className="w-full">
+                      회원가입
+                    </Button>
+                  </SignupPromptDialog>
+                </div>
               </div>
 
               <div className="pt-6 border-t border-[var(--border)]">
@@ -167,7 +181,7 @@ export function PersonalizedPoliciesPage() {
             <div className="w-full lg:w-[420px]">
               <MatchSummaryCard
                 userCondition={{
-                  age: user?.age,
+                  age: user?.age ?? undefined,
                   region: user ? formatRegionCode(user.regionCode) : undefined,
                   interests: user?.interests,
                 }}

--- a/frontend/src/app/pages/PoliciesPage.tsx
+++ b/frontend/src/app/pages/PoliciesPage.tsx
@@ -112,8 +112,9 @@ function getRecommendedScore(policy: PolicyListItem) {
 
   let score = 0;
   if (policy.categories.some((category) => user.interests.includes(category))) score += 42;
-  if (policy.regionCodes.includes(user.regionCode)) score += 26;
+  if (user.regionCode && policy.regionCodes.includes(user.regionCode)) score += 26;
   if (
+    user.age !== null &&
     (policy.minAge === null || user.age >= policy.minAge) &&
     (policy.maxAge === null || user.age <= policy.maxAge)
   ) {
@@ -397,14 +398,14 @@ export function PoliciesPage() {
                     </button>
                   )}
                   {periodRawCount > 0 && (
-                    <button type="button" onClick={() => setStatusFilter(p => p === 'period_raw' ? null : 'period_raw')} className={`flex items-center gap-1.5 px-2.5 py-1 font-semibold rounded-full border transition-all cursor-pointer ${statusFilter === 'period_raw' ? 'bg-amber-200 border-amber-400 text-amber-800' : 'bg-amber-50 text-amber-700 border-amber-200 hover:opacity-80'}`}>
-                      <span className="w-1.5 h-1.5 rounded-full bg-amber-500 inline-block" />
-                      별도 확인 {periodRawCount}
+                    <button type="button" onClick={() => setStatusFilter(p => p === 'period_raw' ? null : 'period_raw')} className={`flex items-center gap-1.5 px-2.5 py-1 font-semibold rounded-full border transition-all cursor-pointer ${statusFilter === 'period_raw' ? 'bg-[#00FFFF]/25 border-[#00D9D9] text-[#006B6B]' : 'bg-[#00FFFF]/10 text-[#007A7A] border-[#00D9D9]/60 hover:bg-[#00FFFF]/20'}`}>
+                      <span className="w-1.5 h-1.5 rounded-full bg-[#00D9D9] inline-block" />
+                      정책별 확인 {periodRawCount}
                     </button>
                   )}
                   {unknownCount > 0 && (
-                    <button type="button" onClick={() => setStatusFilter(p => p === 'unknown' ? null : 'unknown')} className={`flex items-center gap-1.5 px-2.5 py-1 font-semibold rounded-full border transition-all cursor-pointer ${statusFilter === 'unknown' ? 'bg-red-200 border-red-400 text-red-800' : 'bg-red-50 text-red-700 border-red-200 hover:opacity-80'}`}>
-                      <span className="w-1.5 h-1.5 rounded-full bg-red-500 inline-block" />
+                    <button type="button" onClick={() => setStatusFilter(p => p === 'unknown' ? null : 'unknown')} className={`flex items-center gap-1.5 px-2.5 py-1 font-semibold rounded-full border transition-all cursor-pointer ${statusFilter === 'unknown' ? 'bg-amber-200 border-amber-400 text-amber-800' : 'bg-amber-50 text-amber-700 border-amber-200 hover:opacity-80'}`}>
+                      <span className="w-1.5 h-1.5 rounded-full bg-amber-500 inline-block" />
                       기간확인불가 {unknownCount}
                     </button>
                   )}

--- a/frontend/src/app/pages/PolicyDetailPage.tsx
+++ b/frontend/src/app/pages/PolicyDetailPage.tsx
@@ -26,7 +26,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { motion, AnimatePresence } from 'motion/react';
-import { ApiClientError, getAccessToken, getStoredUserProfile } from '../api/client';
+import { ApiClientError, getAccessToken, getEmailVerificationPath, getStoredUserProfile, isEmailVerificationRequiredError } from '../api/client';
 import { checkEligibility, getPolicies, getPolicyDetail, getPolicyDetailWithUser } from '../api/policies';
 import { updateMyPolicyState, removeMyPolicy } from '../api/me';
 import { MainLayout } from '../components/templates/MainLayout';
@@ -369,6 +369,12 @@ export function PolicyDetailPage() {
       setEligibilityResult(response);
       toast.success('자격 확인이 완료되었습니다');
     } catch (error) {
+      if (isEmailVerificationRequiredError(error)) {
+        const email = getStoredUserProfile()?.email;
+        toast.error('이메일 인증 후 자격확인을 이용할 수 있어요.');
+        navigate(getEmailVerificationPath(email));
+        return;
+      }
       const message = error instanceof ApiClientError ? error.message : '자격 확인에 실패했습니다';
       toast.error(message);
     }
@@ -384,6 +390,12 @@ export function PolicyDetailPage() {
       setBookmarked(next);
       toast.success(next ? '정책이 저장되었습니다' : '저장을 취소했습니다');
     } catch (error) {
+      if (isEmailVerificationRequiredError(error)) {
+        const email = getStoredUserProfile()?.email;
+        toast.error('이메일 인증 후 정책을 저장할 수 있어요.');
+        navigate(getEmailVerificationPath(email));
+        return;
+      }
       const message = error instanceof ApiClientError ? error.message : '저장에 실패했습니다';
       toast.error(message);
     }
@@ -405,10 +417,11 @@ export function PolicyDetailPage() {
   // 마크다운 기호, 공백, 불릿 제거 후 실제 텍스트가 있을 때만 표시
   const selectionCriteria = rawCriteria && rawCriteria.replace(/[\s\-*•·]/g, '').length > 0 ? rawCriteria : null;
 
-  const hasRequirements = (policy?.requirements ?? [])
+  const visibleRequirements = (policy?.requirements ?? [])
     .filter((req, i, arr) => arr.findIndex((r) => r.key === req.key) === i)
-    .filter((req) => req.key !== 'selection_criteria' && req.label !== '선정기준')
-    .length > 0;
+    .filter((req) => req.key !== 'selection_criteria' && req.label !== '선정기준');
+  const hasRequirements = visibleRequirements.length > 0;
+  const completedRequirementCount = visibleRequirements.filter((req) => eligibilityAnswers[req.key]).length;
   // [임시] UI 확인용 — 아동복지시설 보호아동지원 정책을 info처럼 동작하게 처리 (확인 후 아래 한 줄 제거)
   const TEMP_INFO_POLICY_ID = 'de99e7da-360c-4071-9899-1d6ded895d60';
   const isInfoPolicy = policy?.policyType === 'info' || policy?.id === TEMP_INFO_POLICY_ID;
@@ -522,7 +535,7 @@ export function PolicyDetailPage() {
               agency={policy.providerName}
               region={formatRegionCodes(policy.regionCodes)}
               period={formatPolicyPeriod(policy.startsAt, policy.endsAt, policy.isAlwaysOpen, policy.periodRaw)}
-              periodClassName={!policy.isAlwaysOpen && !(policy.startsAt && policy.endsAt) ? 'text-red-500' : undefined}
+              periodClassName={!policy.isAlwaysOpen && !(policy.startsAt && policy.endsAt) ? policy.periodRaw ? 'text-[#007A7A]' : 'text-amber-600' : undefined}
               className="flex-wrap overflow-visible"
             />
 
@@ -668,27 +681,34 @@ export function PolicyDetailPage() {
                       : 'bg-emerald-50 border-emerald-200',
               )}
             >
-              <div className="flex items-center gap-2.5 mb-4">
-                <div className={cn(
-                  'w-8 h-8 rounded-lg flex items-center justify-center',
-                  !canCheckEligibility ? 'bg-slate-100' : eligibilityResult?.result === 'conditional' ? 'bg-amber-100' : eligibilityResult?.result === 'ineligible' ? 'bg-rose-100' : 'bg-emerald-100',
-                )}>
-                  {!canCheckEligibility
-                    ? <Info className="h-4 w-4 text-slate-500" />
-                    : eligibilityResult?.result === 'conditional' || eligibilityResult?.result === 'ineligible'
-                      ? <AlertTriangle className={cn('h-4 w-4', eligibilityResult.result === 'conditional' ? 'text-amber-600' : 'text-rose-600')} />
-                      : <CheckCircle2 className="h-4 w-4 text-emerald-600" />}
+              <div className="mb-4 flex items-start justify-between gap-3">
+                <div className="flex items-start gap-2.5">
+                  <div className={cn(
+                    'w-8 h-8 rounded-lg flex items-center justify-center shrink-0',
+                    !canCheckEligibility ? 'bg-slate-100' : eligibilityResult?.result === 'conditional' ? 'bg-amber-100' : eligibilityResult?.result === 'ineligible' ? 'bg-rose-100' : 'bg-emerald-100',
+                  )}>
+                    {!canCheckEligibility
+                      ? <Info className="h-4 w-4 text-slate-500" />
+                      : eligibilityResult?.result === 'conditional' || eligibilityResult?.result === 'ineligible'
+                        ? <AlertTriangle className={cn('h-4 w-4', eligibilityResult.result === 'conditional' ? 'text-amber-600' : 'text-rose-600')} />
+                        : <CheckCircle2 className="h-4 w-4 text-emerald-600" />}
+                  </div>
+                  <div>
+                    <h2 className={cn(
+                      'text-base font-semibold',
+                      !canCheckEligibility ? 'text-slate-700' : eligibilityResult?.result === 'conditional' ? 'text-amber-900' : eligibilityResult?.result === 'ineligible' ? 'text-rose-900' : 'text-emerald-900',
+                    )}>내가 맞는지 확인하기</h2>
+                    <p className={cn(
+                      'text-xs',
+                      !canCheckEligibility ? 'text-slate-500' : eligibilityResult?.result === 'conditional' ? 'text-amber-700/70' : eligibilityResult?.result === 'ineligible' ? 'text-rose-700/70' : 'text-emerald-700/70',
+                    )}>간단한 정보를 입력하면 신청 가능 여부를 확인할 수 있어요</p>
+                  </div>
                 </div>
-                <div>
-                  <h2 className={cn(
-                    'text-base font-semibold',
-                    !canCheckEligibility ? 'text-slate-700' : eligibilityResult?.result === 'conditional' ? 'text-amber-900' : eligibilityResult?.result === 'ineligible' ? 'text-rose-900' : 'text-emerald-900',
-                  )}>내가 맞는지 확인하기</h2>
-                  <p className={cn(
-                    'text-xs',
-                    !canCheckEligibility ? 'text-slate-500' : eligibilityResult?.result === 'conditional' ? 'text-amber-700/70' : eligibilityResult?.result === 'ineligible' ? 'text-rose-700/70' : 'text-emerald-700/70',
-                  )}>간단한 정보를 입력하면 신청 가능 여부를 확인할 수 있어요</p>
-                </div>
+                {canCheckEligibility && showEligibilityForm && !eligibilityResult && (
+                  <span className="hidden shrink-0 rounded-full border border-emerald-200 bg-white px-3 py-1 text-xs font-semibold text-emerald-700 sm:inline-flex">
+                    {completedRequirementCount}/{visibleRequirements.length} 입력 완료
+                  </span>
+                )}
               </div>
 
               {!canCheckEligibility && !isInfoPolicy && (
@@ -737,17 +757,34 @@ export function PolicyDetailPage() {
                   <motion.form
                     initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto' }} exit={{ opacity: 0, height: 0 }}
                     onSubmit={handleCheckEligibility}
-                    className="space-y-3 bg-white/70 rounded-xl p-4 border border-emerald-200"
+                    className="space-y-3"
                   >
-                    {(policy?.requirements ?? [])
-                      .filter((req, i, arr) => arr.findIndex((r) => r.key === req.key) === i)
-                      .filter((req) => req.key !== 'selection_criteria' && req.label !== '선정기준')
-                      .map((req) => (
-                        <div key={req.key}>
-                          <label htmlFor={`req-${req.key}`} className="block mb-1.5 text-sm font-medium text-[var(--foreground)]">
-                            {req.label ?? req.key}
-                            {req.isRequired && <span className="text-[var(--destructive)] ml-1">*</span>}
-                          </label>
+                    {visibleRequirements.map((req, index) => {
+                      const isCompleted = Boolean(eligibilityAnswers[req.key]);
+
+                      return (
+                        <div
+                          key={req.key}
+                          className={cn(
+                            'rounded-2xl border bg-white p-4 shadow-sm transition-all',
+                            isCompleted ? 'border-emerald-200 ring-1 ring-emerald-100' : 'border-[var(--border)] hover:border-emerald-200',
+                          )}
+                        >
+                          <div className="mb-3 flex items-center justify-between gap-3">
+                            <label htmlFor={`req-${req.key}`} className="flex min-w-0 items-center gap-2 text-sm font-semibold text-[var(--foreground)]">
+                              <span className={cn(
+                                'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold',
+                                isCompleted ? 'bg-emerald-600 text-white' : 'bg-emerald-50 text-emerald-700',
+                              )}>
+                                {isCompleted ? <CheckCircle2 className="h-3.5 w-3.5" /> : index + 1}
+                              </span>
+                              <span className="truncate">
+                                {req.label ?? req.key}
+                                {req.isRequired && <span className="text-[var(--destructive)] ml-1">*</span>}
+                              </span>
+                            </label>
+                            {isCompleted && <span className="shrink-0 text-xs font-medium text-emerald-700">입력됨</span>}
+                          </div>
                           {req.type === 'select' && req.options ? (
                             <CustomSelect
                               value={eligibilityAnswers[req.key] ?? ''}
@@ -760,7 +797,7 @@ export function PolicyDetailPage() {
                                 <button
                                   key={val} type="button"
                                   onClick={() => setEligibilityAnswers((prev) => ({ ...prev, [req.key]: val }))}
-                                  className={`flex-1 py-1.5 rounded-lg border text-sm font-medium transition-colors cursor-pointer ${
+                                  className={`flex-1 py-2 rounded-xl border text-sm font-medium transition-colors cursor-pointer ${
                                     eligibilityAnswers[req.key] === val
                                       ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
                                       : 'border-[var(--border)] bg-white text-[var(--foreground)] hover:bg-[var(--muted)]'
@@ -776,14 +813,42 @@ export function PolicyDetailPage() {
                               type={req.type === 'number' ? 'number' : 'text'}
                               value={eligibilityAnswers[req.key] ?? ''}
                               onChange={(e) => setEligibilityAnswers((prev) => ({ ...prev, [req.key]: e.target.value }))}
-                              className="text-sm h-9"
+                              className="h-10 rounded-xl text-sm"
                             />
                           )}
                         </div>
-                      ))}
-                    <div className="flex gap-2 pt-1">
-                      <Button type="submit" className="flex-1 bg-emerald-600 hover:bg-emerald-700 text-sm h-9">확인하기</Button>
-                      <Button type="button" variant="ghost" className="text-sm h-9" onClick={() => setShowEligibilityForm(false)}>취소</Button>
+                      );
+                    })}
+                    <div className="rounded-2xl border border-emerald-200 bg-white p-3 shadow-sm">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                          <p className="text-sm font-semibold text-emerald-900">
+                            {visibleRequirements.length}개 중 {completedRequirementCount}개 입력됨
+                          </p>
+                          <div className="mt-2 h-1.5 w-full rounded-full bg-emerald-100 sm:w-44">
+                            <div
+                              className="h-full rounded-full bg-emerald-500 transition-all"
+                              style={{ width: `${visibleRequirements.length ? (completedRequirementCount / visibleRequirements.length) * 100 : 0}%` }}
+                            />
+                          </div>
+                        </div>
+                        <div className="flex flex-col gap-2 sm:flex-row">
+                          <Button
+                            type="submit"
+                            className="h-10 w-full min-w-32 bg-emerald-600 px-6 text-sm hover:bg-emerald-700 sm:w-auto"
+                          >
+                            확인하기
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            className="h-10 w-full px-5 text-sm sm:w-auto"
+                            onClick={() => setShowEligibilityForm(false)}
+                          >
+                            취소
+                          </Button>
+                        </div>
+                      </div>
                     </div>
                   </motion.form>
                 )}

--- a/frontend/src/app/pages/ProfilePage.tsx
+++ b/frontend/src/app/pages/ProfilePage.tsx
@@ -1,155 +1,105 @@
-import { Link } from 'react-router';
-import { User, MapPin, Sparkles, Edit2, Bookmark, ChevronRight, Gift, Settings } from 'lucide-react';
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router';
+import { LockKeyhole, ShieldAlert, User } from 'lucide-react';
 import { MainLayout } from '../components/templates/MainLayout';
 import { Button } from '../components/atoms/Button';
-import { Badge } from '../components/atoms/Badge';
-import { getStoredUserProfile } from '../api/client';
-import { formatRegionCode } from '../lib/regions';
-
-const interestLabels: Record<string, string> = {
-  youth_policy: '청년정책',
-  childcare_policy: '육아정책',
-};
+import { Input } from '../components/atoms/Input';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
+import { getEmailVerificationPath, getStoredUserProfile } from '../api/client';
 
 export function ProfilePage() {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const user = getStoredUserProfile();
   const userName = user ? user.email.split('@')[0] : '사용자';
-  const region = user ? formatRegionCode(user.regionCode) : null;
-  const interests = user ? user.interests.map((i) => interestLabels[i] ?? i) : [];
+  const activeTab = searchParams.get('tab') === 'withdraw' ? 'withdraw' : 'password';
+
+  useEffect(() => {
+    if (user && !user.emailVerified) {
+      navigate(getEmailVerificationPath(user.email), { replace: true });
+      return;
+    }
+
+    if (user && !user.profileCompleted) {
+      navigate('/onboarding', { replace: true });
+    }
+  }, [navigate, user]);
 
   return (
     <MainLayout>
-      {/* 헤더 배너 */}
-      <div className="bg-gradient-to-br from-blue-600 via-indigo-600 to-purple-600 h-36 sm:h-44 relative">
-        <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGNpcmNsZSBjeD0iMzAiIGN5PSIzMCIgcj0iMiIgZmlsbD0icmdiYSgyNTUsMjU1LDI1NSwwLjA4KSIvPjwvc3ZnPg==')] opacity-60" />
-      </div>
-
-      <div className="container mx-auto px-4">
-        {/* 아바타 + 이름 영역 */}
-        <div className="relative flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 -mt-14 mb-6">
-          <div className="flex items-end gap-4">
-            <div className="w-24 h-24 sm:w-28 sm:h-28 rounded-2xl bg-gradient-to-br from-blue-100 to-indigo-200 border-4 border-white shadow-lg flex items-center justify-center flex-shrink-0">
-              <User className="h-12 w-12 sm:h-14 sm:h-14 text-blue-500" />
+      <div className="bg-[var(--background)] py-8 sm:py-10">
+        <div className="container mx-auto px-4">
+          <div className="mb-6 flex items-center gap-3">
+            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-blue-50">
+              <User className="h-5 w-5 text-blue-600" />
             </div>
-            <div className="pb-1">
-              <h1 className="text-xl sm:text-2xl font-bold text-[var(--foreground)]">{userName}</h1>
-              <p className="text-sm text-[var(--muted-foreground)]">{user?.email ?? ''}</p>
+            <div className="min-w-0">
+              <h1 className="text-xl font-semibold text-[var(--foreground)]">계정 설정</h1>
+              <p className="truncate text-sm text-[var(--muted-foreground)]">{userName} · {user?.email ?? ''}</p>
             </div>
           </div>
-          <div className="flex gap-2 sm:pb-1">
-            <Link to="/me">
-              <Button variant="secondary" size="sm" className="gap-1.5">
-                <Bookmark className="h-4 w-4" />
-                저장 정책
-              </Button>
-            </Link>
-            <Button variant="secondary" size="sm" className="gap-1.5">
-              <Edit2 className="h-4 w-4" />
-              프로필 수정
-            </Button>
-          </div>
-        </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 pb-12">
-          {/* 왼쪽: 기본 정보 */}
-          <div className="lg:col-span-1 space-y-4">
-            {/* 기본 정보 카드 */}
-            <div className="bg-white rounded-2xl border border-[var(--border)] p-5 shadow-sm">
-              <h2 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wider mb-4">기본 정보</h2>
-              <div className="space-y-3">
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center flex-shrink-0">
-                    <Sparkles className="h-4 w-4 text-blue-500" />
+          <Tabs
+            value={activeTab}
+            onValueChange={(tab) => setSearchParams({ tab }, { replace: true })}
+            className="max-w-2xl"
+          >
+            <TabsList className="mb-5 grid h-12 w-full grid-cols-2 rounded-2xl bg-white p-1.5 shadow-sm border border-[var(--border)]">
+              <TabsTrigger
+                value="password"
+                className="rounded-xl text-[var(--muted-foreground)] transition-all hover:bg-blue-50 hover:text-blue-700 data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-sm"
+              >
+                비밀번호 변경
+              </TabsTrigger>
+              <TabsTrigger
+                value="withdraw"
+                className="rounded-xl text-[var(--muted-foreground)] transition-all hover:bg-red-50 hover:text-red-700 data-[state=active]:bg-red-600 data-[state=active]:text-white data-[state=active]:shadow-sm"
+              >
+                회원탈퇴
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="password">
+              <section className="rounded-2xl border border-[var(--border)] bg-white p-5 shadow-sm sm:p-6">
+                <div className="mb-6 flex items-start gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-50">
+                    <LockKeyhole className="h-5 w-5 text-blue-600" />
                   </div>
                   <div>
-                    <p className="text-xs text-[var(--muted-foreground)]">나이</p>
-                    <p className="text-sm font-medium">{user?.age ? `${user.age}세` : '미입력'}</p>
+                    <h2 className="text-lg font-semibold text-[var(--foreground)]">비밀번호 변경</h2>
+                    <p className="mt-1 text-sm text-[var(--muted-foreground)]">백엔드 API가 준비되면 연결할 예정입니다.</p>
                   </div>
                 </div>
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-lg bg-emerald-50 flex items-center justify-center flex-shrink-0">
-                    <MapPin className="h-4 w-4 text-emerald-500" />
+                <div className="space-y-4">
+                  <Input type="password" placeholder="현재 비밀번호" disabled />
+                  <Input type="password" placeholder="새 비밀번호" disabled />
+                  <Input type="password" placeholder="새 비밀번호 확인" disabled />
+                  <Button disabled className="w-full sm:w-auto">변경하기</Button>
+                </div>
+              </section>
+            </TabsContent>
+
+            <TabsContent value="withdraw">
+              <section className="rounded-2xl border border-red-100 bg-white p-5 shadow-sm sm:p-6">
+                <div className="mb-6 flex items-start gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-red-50">
+                    <ShieldAlert className="h-5 w-5 text-red-600" />
                   </div>
                   <div>
-                    <p className="text-xs text-[var(--muted-foreground)]">거주 지역</p>
-                    <p className="text-sm font-medium">{region ?? '미입력'}</p>
+                    <h2 className="text-lg font-semibold text-[var(--foreground)]">회원탈퇴</h2>
+                    <p className="mt-1 text-sm text-[var(--muted-foreground)]">탈퇴 API가 준비되면 확인 절차와 연결할 예정입니다.</p>
                   </div>
                 </div>
-              </div>
-            </div>
-
-            {/* 관심사 카드 */}
-            <div className="bg-white rounded-2xl border border-[var(--border)] p-5 shadow-sm">
-              <h2 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wider mb-4">관심사</h2>
-              {interests.length > 0 ? (
-                <div className="flex flex-wrap gap-2">
-                  {interests.map((interest) => (
-                    <Badge key={interest} variant="default" className="bg-blue-50 text-blue-700 border-blue-200">
-                      {interest}
-                    </Badge>
-                  ))}
+                <div className="rounded-xl border border-red-100 bg-red-50 px-4 py-3 text-sm text-red-700">
+                  저장한 정책, 맞춤 정보, 계정 데이터 삭제 안내 영역입니다.
                 </div>
-              ) : (
-                <p className="text-sm text-[var(--muted-foreground)]">등록된 관심사가 없습니다</p>
-              )}
-            </div>
-
-            {/* 설정 링크 */}
-            <div className="bg-white rounded-2xl border border-[var(--border)] shadow-sm overflow-hidden">
-              <button className="w-full flex items-center justify-between px-5 py-4 hover:bg-[var(--muted)] transition-colors">
-                <div className="flex items-center gap-3">
-                  <Settings className="h-4 w-4 text-[var(--muted-foreground)]" />
-                  <span className="text-sm font-medium">계정 설정</span>
+                <div className="mt-4 space-y-4">
+                  <Input placeholder="탈퇴 확인 문구 입력" disabled />
+                  <Button variant="danger" disabled className="w-full sm:w-auto">탈퇴하기</Button>
                 </div>
-                <ChevronRight className="h-4 w-4 text-[var(--muted-foreground)]" />
-              </button>
-            </div>
-          </div>
-
-          {/* 오른쪽: 활동 / 빠른 링크 */}
-          <div className="lg:col-span-2 space-y-4">
-            {/* 프로필 완성도 */}
-            <div className="bg-white rounded-2xl border border-[var(--border)] p-5 shadow-sm">
-              <div className="flex items-center justify-between mb-3">
-                <h2 className="text-sm font-semibold">프로필 완성도</h2>
-                <span className="text-sm font-bold text-[var(--accent)]">
-                  {Math.round(((user?.age ? 1 : 0) + (user?.regionCode ? 1 : 0) + ((user?.interests.length ?? 0) > 0 ? 1 : 0)) / 3 * 100)}%
-                </span>
-              </div>
-              <div className="w-full bg-[var(--muted)] rounded-full h-2 mb-3">
-                <div
-                  className="bg-gradient-to-r from-blue-500 to-purple-500 h-2 rounded-full transition-all duration-500"
-                  style={{ width: `${Math.round(((user?.age ? 1 : 0) + (user?.regionCode ? 1 : 0) + ((user?.interests.length ?? 0) > 0 ? 1 : 0)) / 3 * 100)}%` }}
-                />
-              </div>
-              <p className="text-xs text-[var(--muted-foreground)]">프로필을 완성하면 더 정확한 맞춤 정책을 추천받을 수 있어요</p>
-            </div>
-
-            {/* 빠른 이동 */}
-            <div className="bg-white rounded-2xl border border-[var(--border)] shadow-sm overflow-hidden">
-              <div className="px-5 pt-5 pb-2">
-                <h2 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wider">바로가기</h2>
-              </div>
-              <Link to="/me" className="flex items-center justify-between px-5 py-4 hover:bg-[var(--muted)] transition-colors border-t border-[var(--border)]">
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center">
-                    <Bookmark className="h-4 w-4 text-blue-500" />
-                  </div>
-                  <span className="text-sm font-medium">저장한 정책 관리</span>
-                </div>
-                <ChevronRight className="h-4 w-4 text-[var(--muted-foreground)]" />
-              </Link>
-              <Link to="/personalized" className="flex items-center justify-between px-5 py-4 hover:bg-[var(--muted)] transition-colors border-t border-[var(--border)]">
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-lg bg-purple-50 flex items-center justify-center">
-                    <Gift className="h-4 w-4 text-purple-500" />
-                  </div>
-                  <span className="text-sm font-medium">나를 위한 맞춤 정책</span>
-                </div>
-                <ChevronRight className="h-4 w-4 text-[var(--muted-foreground)]" />
-              </Link>
-            </div>
-          </div>
+              </section>
+            </TabsContent>
+          </Tabs>
         </div>
       </div>
     </MainLayout>

--- a/frontend/src/app/pages/SignupPage.tsx
+++ b/frontend/src/app/pages/SignupPage.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router';
 import { ArrowRight } from 'lucide-react';
 import { toast } from 'sonner';
 import { signup } from '../api/auth';
-import { ApiClientError } from '../api/client';
+import { ApiClientError, getEmailVerificationPath } from '../api/client';
 import { Button } from '../components/atoms/Button';
 import { Input } from '../components/atoms/Input';
 import { Chip } from '../components/atoms/Chip';
@@ -90,8 +90,8 @@ export function SignupPage() {
         interests: interestList,
       });
 
-      toast.success('회원가입이 완료되었습니다.');
-      navigate('/policies');
+      toast.success('인증 메일을 보냈습니다.');
+      navigate(getEmailVerificationPath(formData.email));
     } catch (error) {
       const message = error instanceof ApiClientError ? error.message : '회원가입에 실패했습니다. 다시 시도해주세요.';
       toast.error(message);

--- a/frontend/src/app/routes.ts
+++ b/frontend/src/app/routes.ts
@@ -8,6 +8,11 @@ import { MyPage } from './pages/MyPage';
 import { HomePage } from './pages/HomePage';
 import { PersonalizedPoliciesPage } from './pages/PersonalizedPoliciesPage';
 import { ProfilePage } from './pages/ProfilePage';
+import { OAuthCallbackPage } from './pages/OAuthCallbackPage';
+import { OnboardingPage } from './pages/OnboardingPage';
+import { CheckEmailPage } from './pages/CheckEmailPage';
+import { EmailVerifiedPage } from './pages/EmailVerifiedPage';
+import { RouteErrorFallback } from './components/RouteErrorFallback';
 
 function RootLayout() {
   return createElement(
@@ -21,6 +26,7 @@ function RootLayout() {
 export const router = createBrowserRouter([
   {
     Component: RootLayout,
+    ErrorBoundary: RouteErrorFallback,
     children: [
       {
         path: '/',
@@ -33,6 +39,22 @@ export const router = createBrowserRouter([
       {
         path: '/login',
         Component: LoginPage,
+      },
+      {
+        path: '/oauth/callback',
+        Component: OAuthCallbackPage,
+      },
+      {
+        path: '/check-email',
+        Component: CheckEmailPage,
+      },
+      {
+        path: '/email-verified',
+        Component: EmailVerifiedPage,
+      },
+      {
+        path: '/onboarding',
+        Component: OnboardingPage,
       },
       {
         path: '/policies',

--- a/frontend/src/app/types/user.ts
+++ b/frontend/src/app/types/user.ts
@@ -1,21 +1,57 @@
 export type Gender = 'male' | 'female' | 'other' | 'unspecified';
 
-export type RegionCode = 'seoul';
+export type RegionCode =
+  | 'seoul'
+  | 'seoul_gangnam'
+  | 'seoul_gangdong'
+  | 'seoul_gangbuk'
+  | 'seoul_gangseo'
+  | 'seoul_gwanak'
+  | 'seoul_gwangjin'
+  | 'seoul_guro'
+  | 'seoul_geumcheon'
+  | 'seoul_nowon'
+  | 'seoul_dobong'
+  | 'seoul_dongdaemun'
+  | 'seoul_dongjak'
+  | 'seoul_mapo'
+  | 'seoul_seodaemun'
+  | 'seoul_seocho'
+  | 'seoul_seongdong'
+  | 'seoul_seongbuk'
+  | 'seoul_songpa'
+  | 'seoul_yangcheon'
+  | 'seoul_yeongdeungpo'
+  | 'seoul_yongsan'
+  | 'seoul_eunpyeong'
+  | 'seoul_jongno'
+  | 'seoul_jung'
+  | 'seoul_jungnang';
 
 export type InterestCategory = 'youth_policy' | 'childcare_policy';
 
 export interface UserProfileSummary {
   userId: string;
   email: string;
-  age: number;
-  gender: Gender;
-  regionCode: RegionCode;
+  emailVerified: boolean;
+  profileCompleted: boolean;
+  displayName: string | null;
+  age: number | null;
+  gender: Gender | null;
+  regionCode: RegionCode | null;
   interests: InterestCategory[];
 }
 
 export interface SignupRequest {
   email: string;
   password: string;
+  age: number;
+  gender: Gender;
+  regionCode: RegionCode;
+  interests: InterestCategory[];
+}
+
+export interface CompleteProfileRequest {
   age: number;
   gender: Gender;
   regionCode: RegionCode;


### PR DESCRIPTION
-OAuth 진입 버튼을 백엔드 `/auth/google`, `/auth/naver` 엔드포인트로 연결
- OAuth callback 페이지(`/oauth/callback`)와 온보딩 페이지(`/onboarding`) 추가
- 일반 회원가입 후 이메일 인증 안내 화면(`/check-email`)과 인증 완료 화면(`/email-verified`) 추가
- 이메일 미인증 사용자에 대한 403 처리 및 인증 안내 페이지 이동 처리
- 로그인/회원가입/헤더의 가입 플로우 정리
- 계정 메뉴를 드롭다운으로 변경하고 비밀번호 변경/회원탈퇴 스켈레톤 추가
- 정책 상태 색상 정리
- 정책별 확인 색상 분리
- 기간확인불가 색상 조정
- 자격확인 폼 UI를 질문 카드형 + 진행도 표시 구조로 개선