### PR TITLE
Fix frontend policy filters and account flows

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,13 +1,16 @@
 import { RouterProvider } from 'react-router';
+import { ThemeProvider } from 'next-themes';
 import { router } from './routes';
-import { Toaster } from 'sonner';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { Toaster } from './components/ui/sonner';
 
 export default function App() {
   return (
-    <ErrorBoundary>
-      <RouterProvider router={router} />
-      <Toaster position="top-center" richColors offset="80px" />
-    </ErrorBoundary>
+    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false} storageKey="bengo-theme" disableTransitionOnChange>
+      <ErrorBoundary>
+        <RouterProvider router={router} />
+        <Toaster position="top-center" richColors offset="80px" />
+      </ErrorBoundary>
+    </ThemeProvider>
   );
 }

--- a/frontend/src/app/api/auth.ts
+++ b/frontend/src/app/api/auth.ts
@@ -1,5 +1,15 @@
-import { apiRequest, setAccessToken, setStoredUserProfile } from './client';
-import type { AuthResponse, CompleteProfileRequest, LoginRequest, SignupRequest } from '../types/user';
+import { apiRequest, setAccessToken, setAuthMethod, setStoredUserProfile } from './client';
+import type {
+  AuthResponse,
+  ChangePasswordRequest,
+  CompleteProfileRequest,
+  DeleteAccountRequest,
+  LoginRequest,
+  SignupRequest,
+  UpdateProfileRequest,
+} from '../types/user';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:4000';
 
 export async function signup(payload: SignupRequest) {
   const response = await apiRequest<AuthResponse>('/auth/signup', {
@@ -7,8 +17,12 @@ export async function signup(payload: SignupRequest) {
     body: payload,
   });
 
-  setAccessToken(response.accessToken);
-  setStoredUserProfile(response.user);
+  if (response.user.emailVerified) {
+    setAccessToken(response.accessToken);
+    setAuthMethod('password');
+    setStoredUserProfile(response.user);
+  }
+
   return response;
 }
 
@@ -18,8 +32,12 @@ export async function login(payload: LoginRequest) {
     body: payload,
   });
 
-  setAccessToken(response.accessToken);
-  setStoredUserProfile(response.user);
+  if (response.user.emailVerified) {
+    setAccessToken(response.accessToken);
+    setAuthMethod('password');
+    setStoredUserProfile(response.user);
+  }
+
   return response;
 }
 
@@ -35,9 +53,43 @@ export async function completeProfile(payload: CompleteProfileRequest) {
   return response;
 }
 
+export async function updateProfile(payload: UpdateProfileRequest) {
+  const response = await apiRequest<AuthResponse>('/auth/profile', {
+    method: 'PATCH',
+    body: payload,
+    auth: true,
+  });
+
+  setAccessToken(response.accessToken);
+  setStoredUserProfile(response.user);
+  return response;
+}
+
+export async function changePassword(payload: ChangePasswordRequest) {
+  return apiRequest<void>('/auth/change-password', {
+    method: 'POST',
+    body: payload,
+    auth: true,
+  });
+}
+
+export async function deleteAccount(payload: DeleteAccountRequest = {}) {
+  return apiRequest<void>('/auth/delete-account', {
+    method: 'POST',
+    body: payload,
+    auth: true,
+  });
+}
+
 export async function resendVerification(email: string) {
   return apiRequest<{ message: string }>('/auth/resend-verification', {
     method: 'POST',
     body: { email },
   });
+}
+
+export function getEmailVerificationUrl(token: string) {
+  const url = new URL('/auth/verify-email', API_BASE_URL);
+  url.searchParams.set('token', token);
+  return url.toString();
 }

--- a/frontend/src/app/api/client.ts
+++ b/frontend/src/app/api/client.ts
@@ -4,6 +4,9 @@ import type { UserProfileSummary } from '../types/user';
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:4000';
 const ACCESS_TOKEN_KEY = 'bengo_access_token';
 const USER_PROFILE_KEY = 'bengo_user_profile';
+const AUTH_METHOD_KEY = 'bengo_auth_method';
+
+export type AuthMethod = 'password' | 'oauth';
 
 export class ApiClientError extends Error {
   status: number;
@@ -31,10 +34,58 @@ function buildUrl(path: string, query?: RequestOptions['query']) {
       continue;
     }
 
+    if (Array.isArray(value)) {
+      value.forEach((item) => {
+        if (item !== '') {
+          url.searchParams.append(key, String(item));
+        }
+      });
+      continue;
+    }
+
     url.searchParams.set(key, String(value));
   }
 
   return url.toString();
+}
+
+function getApiErrorMessage(data: unknown, fallback: string) {
+  if (typeof data !== 'object' || data === null) {
+    return fallback;
+  }
+
+  const error = data as ApiErrorResponse;
+
+  if (typeof error.error === 'object' && error.error?.message) {
+    return error.error.message;
+  }
+
+  if (typeof error.message === 'string') {
+    return error.message;
+  }
+
+  if (Array.isArray(error.message)) {
+    return error.message.join('\n');
+  }
+
+  if (typeof error.error === 'string') {
+    return error.error;
+  }
+
+  return fallback;
+}
+
+function clearAuthSession() {
+  window.localStorage.removeItem(ACCESS_TOKEN_KEY);
+  window.localStorage.removeItem(USER_PROFILE_KEY);
+  window.localStorage.removeItem(AUTH_METHOD_KEY);
+}
+
+function isMissingAuthenticatedUser(status: number, message: string) {
+  return (
+    status === 404 &&
+    (message.includes('사용자') || message.includes('프로필'))
+  );
 }
 
 async function parseResponse(response: Response) {
@@ -57,6 +108,7 @@ export function setAccessToken(token: string) {
 
 export function clearAccessToken() {
   window.localStorage.removeItem(ACCESS_TOKEN_KEY);
+  window.localStorage.removeItem(AUTH_METHOD_KEY);
 }
 
 export function getStoredUserProfile() {
@@ -80,6 +132,19 @@ export function setStoredUserProfile(profile: UserProfileSummary) {
 
 export function clearStoredUserProfile() {
   window.localStorage.removeItem(USER_PROFILE_KEY);
+}
+
+export function getAuthMethod(): AuthMethod | null {
+  const method = window.localStorage.getItem(AUTH_METHOD_KEY);
+  return method === 'password' || method === 'oauth' ? method : null;
+}
+
+export function setAuthMethod(method: AuthMethod) {
+  window.localStorage.setItem(AUTH_METHOD_KEY, method);
+}
+
+export function clearAuthMethod() {
+  window.localStorage.removeItem(AUTH_METHOD_KEY);
 }
 
 export function getEmailVerificationPath(email?: string | null) {
@@ -144,15 +209,26 @@ export async function apiRequest<T>(path: string, options: RequestOptions = {}):
   const data = await parseResponse(response);
 
   if (!response.ok) {
+    const message = getApiErrorMessage(data, response.statusText ?? 'API request failed');
+
     if (response.status === 401) {
-      window.localStorage.removeItem(ACCESS_TOKEN_KEY);
-      window.localStorage.removeItem(USER_PROFILE_KEY);
+      clearAuthSession();
       window.location.href = '/login';
     }
-    const errorBody = typeof data === 'object' && data !== null ? (data as ApiErrorResponse).error : undefined;
+
+    if (auth && isMissingAuthenticatedUser(response.status, message)) {
+      clearAuthSession();
+      window.location.href = '/login';
+    }
+
+    const errorBody =
+      typeof data === 'object' && data !== null && typeof (data as ApiErrorResponse).error === 'object'
+        ? (data as ApiErrorResponse).error
+        : undefined;
+
     throw new ApiClientError(
       response.status,
-      errorBody?.message ?? response.statusText ?? 'API request failed',
+      message,
       errorBody?.code,
       errorBody?.requestId,
     );

--- a/frontend/src/app/api/me.ts
+++ b/frontend/src/app/api/me.ts
@@ -1,16 +1,17 @@
 import { apiRequest } from './client';
 import type { ListResponse } from '../types/api';
-import type { MyPolicyItem, UpdateMyPolicyStateRequest } from '../types/policy';
+import type { MyPolicyItem, UpdatedMyPolicyState, UpdateMyPolicyStateRequest, UserPolicyState } from '../types/policy';
 
-export function getMyPolicies() {
+export function getMyPolicies(state?: UserPolicyState) {
   return apiRequest<ListResponse<MyPolicyItem>>('/me/policies', {
     method: 'GET',
+    query: { state },
     auth: true,
   });
 }
 
 export function updateMyPolicyState(id: string, payload: UpdateMyPolicyStateRequest) {
-  return apiRequest<MyPolicyItem>(`/me/policies/${id}/state`, {
+  return apiRequest<UpdatedMyPolicyState>(`/me/policies/${id}/state`, {
     method: 'PATCH',
     body: payload,
     auth: true,

--- a/frontend/src/app/api/policies.ts
+++ b/frontend/src/app/api/policies.ts
@@ -8,20 +8,93 @@ import type {
   PolicyListItem,
 } from '../types/policy';
 
+type PolicyListResponse = ListResponse<PolicyListItem>;
+
+function getRequestedInterests(params: GetPoliciesParams) {
+  const interests = params.interests?.length
+    ? params.interests
+    : params.interest
+      ? [params.interest]
+      : [];
+
+  return Array.from(new Set(interests));
+}
+
+function getSingleInterestParams(params: GetPoliciesParams, interest?: GetPoliciesParams['interest']) {
+  const { interests: _interests, interest: _interest, ...baseParams } = params;
+  return interest ? { ...baseParams, interest } : baseParams;
+}
+
+function mergePolicyListResponses(responses: PolicyListResponse[]): PolicyListResponse {
+  const items: PolicyListItem[] = [];
+  const indexById = new Map<string, number>();
+
+  for (const response of responses) {
+    for (const item of response.items) {
+      const existingIndex = indexById.get(item.id);
+      if (existingIndex === undefined) {
+        indexById.set(item.id, items.length);
+        items.push(item);
+        continue;
+      }
+
+      const existing = items[existingIndex];
+      const existingScore = existing.fitScore ?? Number.NEGATIVE_INFINITY;
+      const nextScore = item.fitScore ?? Number.NEGATIVE_INFINITY;
+      if (nextScore > existingScore) {
+        items[existingIndex] = item;
+      }
+    }
+  }
+
+  return {
+    total: items.length,
+    items,
+  };
+}
+
+async function getPoliciesByPath(
+  path: '/policies' | '/policies/recommended',
+  params: GetPoliciesParams,
+  auth: boolean,
+) {
+  const interests = getRequestedInterests(params);
+
+  if (interests.length === 0) {
+    return apiRequest<PolicyListResponse>(path, {
+      method: 'GET',
+      query: getSingleInterestParams(params),
+      auth,
+    });
+  }
+
+  if (interests.length === 1) {
+    return apiRequest<PolicyListResponse>(path, {
+      method: 'GET',
+      query: getSingleInterestParams(params, interests[0]),
+      auth,
+    });
+  }
+
+  const responses = await Promise.all(
+    interests.map((interest) =>
+      apiRequest<PolicyListResponse>(path, {
+        method: 'GET',
+        query: getSingleInterestParams(params, interest),
+        auth,
+      }),
+    ),
+  );
+
+  return mergePolicyListResponses(responses);
+}
+
 export function getPolicies(params: GetPoliciesParams = {}) {
-  return apiRequest<ListResponse<PolicyListItem>>('/policies', {
-    method: 'GET',
-    query: params as Record<string, string | number | boolean | undefined | null>,
-    auth: false,
-  });
+  return getPoliciesByPath('/policies', params, false);
 }
 
 export function getPoliciesRecommended(params: GetPoliciesParams = {}) {
-  return apiRequest<ListResponse<PolicyListItem>>('/policies/recommended', {
-    method: 'GET',
-    query: params as Record<string, string | number | boolean | undefined | null>,
-    auth: true,
-  });
+  return getPoliciesByPath('/policies/recommended', params, true);
 }
 
 export function getPolicyDetail(id: string) {

--- a/frontend/src/app/components/atoms/Badge.tsx
+++ b/frontend/src/app/components/atoms/Badge.tsx
@@ -11,14 +11,14 @@ export function Badge({ children, variant = 'default', className }: BadgeProps) 
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium whitespace-nowrap transition-all duration-200',
+        'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold whitespace-nowrap transition-all duration-200',
         {
-          'bg-emerald-500 text-white shadow-sm': variant === 'recruiting',
-          'bg-blue-500 text-white shadow-sm': variant === 'always',
+          'bg-emerald-500 text-white shadow-sm dark:bg-[rgba(52,211,153,0.16)] dark:text-[#6EE7B7] dark:shadow-none': variant === 'recruiting',
+          'bg-blue-500 text-white shadow-sm dark:bg-[rgba(96,165,250,0.16)] dark:text-[#93C5FD] dark:shadow-none': variant === 'always',
           'bg-[var(--muted)] text-[var(--muted-foreground)]': variant === 'closed',
-          'bg-amber-100 text-amber-700 border border-amber-200': variant === 'needsReview',
-          'bg-emerald-100 text-emerald-700 border border-emerald-200': variant === 'eligible',
-          'bg-red-100 text-red-700 border border-red-200': variant === 'notEligible' || variant === 'ineligible',
+          'bg-amber-100 text-amber-700 border border-amber-200 dark:bg-[rgba(251,191,36,0.14)] dark:text-[#FCD34D] dark:border-[rgba(251,191,36,0.24)]': variant === 'needsReview',
+          'bg-emerald-100 text-emerald-700 border border-emerald-200 dark:bg-[rgba(52,211,153,0.14)] dark:text-[#6EE7B7] dark:border-[rgba(52,211,153,0.24)]': variant === 'eligible',
+          'bg-red-100 text-red-700 border border-red-200 dark:bg-[rgba(248,113,113,0.14)] dark:text-[#FCA5A5] dark:border-[rgba(248,113,113,0.24)]': variant === 'notEligible' || variant === 'ineligible',
           'bg-[var(--secondary)] text-[var(--secondary-foreground)] border border-[var(--border)]': variant === 'default',
         },
         className

--- a/frontend/src/app/components/atoms/Button.tsx
+++ b/frontend/src/app/components/atoms/Button.tsx
@@ -20,14 +20,14 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           'disabled:pointer-events-none disabled:opacity-50',
           'cursor-pointer active:scale-[0.97]',
           {
-            'bg-[var(--accent)] text-[var(--accent-foreground)] hover:shadow-lg hover:shadow-blue-500/25 hover:-translate-y-0.5 focus-visible:ring-[var(--accent)]/50':
+            'bg-[var(--accent)] text-[var(--accent-foreground)] hover:shadow-lg hover:shadow-blue-500/25 hover:-translate-y-0.5 focus-visible:ring-[var(--accent)]/50 dark:bg-gradient-to-r dark:from-[#3B82F6] dark:to-[#2563EB] dark:hover:shadow-[0_10px_28px_rgba(59,130,246,0.28)]':
               variant === 'primary',
-            'bg-[var(--secondary)] text-[var(--secondary-foreground)] hover:bg-[var(--muted)] border border-[var(--border)] focus-visible:ring-[var(--accent)]/30':
+            'bg-[var(--secondary)] text-[var(--secondary-foreground)] hover:bg-[var(--muted)] border border-[var(--border)] focus-visible:ring-[var(--accent)]/30 dark:bg-[rgba(30,41,59,0.58)] dark:border-[var(--border-default)] dark:hover:bg-[rgba(30,41,59,0.86)] dark:hover:border-[var(--border-strong)]':
               variant === 'secondary',
-            'border border-[var(--border)] bg-transparent hover:bg-[var(--muted)] focus-visible:ring-[var(--accent)]/30':
+            'border border-[var(--border)] bg-transparent hover:bg-[var(--muted)] focus-visible:ring-[var(--accent)]/30 dark:border-[var(--border-default)] dark:hover:bg-[rgba(30,41,59,0.5)]':
               variant === 'outline',
-            'hover:bg-[var(--muted)] focus-visible:ring-[var(--accent)]/30': variant === 'ghost',
-            'bg-red-500 text-white hover:bg-red-600 hover:shadow-lg hover:shadow-red-500/25 hover:-translate-y-0.5 focus-visible:ring-red-500/50':
+            'hover:bg-[var(--muted)] focus-visible:ring-[var(--accent)]/30 dark:hover:bg-[rgba(30,41,59,0.5)]': variant === 'ghost',
+            'bg-red-500 text-white hover:bg-red-600 hover:shadow-lg hover:shadow-red-500/25 hover:-translate-y-0.5 focus-visible:ring-red-500/50 dark:bg-[#EF4444] dark:hover:bg-[#F87171]':
               variant === 'danger',
           },
           {

--- a/frontend/src/app/components/atoms/Input.tsx
+++ b/frontend/src/app/components/atoms/Input.tsx
@@ -20,10 +20,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           <input
             ref={ref}
             className={cn(
-              'w-full rounded-xl border border-[var(--border)] bg-white px-4 py-2.5 text-sm transition-all duration-200',
+              'w-full rounded-xl border border-[var(--border)] bg-white dark:bg-[rgba(15,23,42,0.82)] dark:border-[var(--border-default)] px-4 py-2.5 text-sm transition-all duration-200',
               'placeholder:text-[var(--muted-foreground)]',
               'hover:border-[var(--accent)]/40',
-              'focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/30 focus:border-[var(--accent)]',
+              'focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/30 focus:border-[var(--accent)] dark:focus:ring-[var(--accent)]/20',
               'disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-[var(--muted)]',
               {
                 'border-[var(--destructive)] focus:ring-[var(--destructive)]/30 focus:border-[var(--destructive)]': error,

--- a/frontend/src/app/components/organisms/BottomNav.tsx
+++ b/frontend/src/app/components/organisms/BottomNav.tsx
@@ -26,7 +26,7 @@ export function BottomNav() {
 
   return (
     <nav
-      className="fixed bottom-0 left-0 right-0 z-50 bg-white/90 backdrop-blur-lg border-t border-[var(--border)] md:hidden"
+      className="fixed bottom-0 left-0 right-0 z-50 bg-white/90 dark:bg-[rgba(8,13,23,0.86)] backdrop-blur-xl border-t border-[var(--border)] dark:border-[var(--border-subtle)] md:hidden"
       aria-label="하단 네비게이션"
     >
       <div className="flex items-stretch h-16">

--- a/frontend/src/app/components/organisms/ExpandableFilters.tsx
+++ b/frontend/src/app/components/organisms/ExpandableFilters.tsx
@@ -40,6 +40,8 @@ const TEMP_VISIBILITY_TEST_OPTIONS = Array.from({ length: 7 }, (_, index) => {
 const categoryOptions = [
   { id: 'youth_policy', label: '청년정책' },
   { id: 'childcare_policy', label: '육아정책' },
+  { id: 'senior_policy', label: '노인정책' },
+  { id: 'disability_policy', label: '장애인정책' },
   ...TEMP_VISIBILITY_TEST_OPTIONS,
 ];
 

--- a/frontend/src/app/components/organisms/Footer.tsx
+++ b/frontend/src/app/components/organisms/Footer.tsx
@@ -2,7 +2,7 @@ import { ArrowRight } from 'lucide-react';
 
 export function Footer() {
   return (
-    <footer className="border-t border-[var(--border)] bg-white mt-auto">
+    <footer className="border-t border-[var(--border)] dark:border-[var(--border-subtle)] bg-white dark:bg-[#070B12] mt-auto">
       <div className="container mx-auto px-4 sm:px-6 py-12">
         <div className="flex flex-col md:flex-row justify-between items-start gap-8">
           <div className="flex flex-col gap-4">

--- a/frontend/src/app/components/organisms/Header.tsx
+++ b/frontend/src/app/components/organisms/Header.tsx
@@ -1,11 +1,12 @@
 import { Link, useLocation } from 'react-router';
-import { ArrowRight, User, LogOut, ChevronDown, LockKeyhole, ShieldAlert } from 'lucide-react';
+import { ArrowRight, User, LogOut, ChevronDown, LockKeyhole, ShieldAlert, Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
 import { Button } from '../atoms/Button';
 import { useState, useEffect } from 'react';
 import { cn } from '../../lib/utils';
 import { NotificationButton } from '../molecules/NotificationButton';
 import { SignupPromptDialog } from '../molecules/SignupPromptDialog';
-import { getAccessToken, getStoredUserProfile, clearAccessToken, clearStoredUserProfile } from '../../api/client';
+import { getAccessToken, getAuthMethod, getStoredUserProfile, clearAccessToken, clearStoredUserProfile } from '../../api/client';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -17,29 +18,40 @@ import {
 
 export function Header() {
   const location = useLocation();
+  const { resolvedTheme, setTheme } = useTheme();
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [userName, setUserName] = useState<string | null>(null);
+  const [isOAuthUser, setIsOAuthUser] = useState(false);
+  const [themeMounted, setThemeMounted] = useState(false);
 
   useEffect(() => {
     const token = getAccessToken();
     const profile = getStoredUserProfile();
     setIsAuthenticated(Boolean(token && profile));
-    setUserName(profile ? profile.email.split('@')[0] : null);
+    setUserName(profile ? profile.displayName || profile.email.split('@')[0] : null);
+    setIsOAuthUser(getAuthMethod() === 'oauth');
   }, [location.pathname]);
+
+  useEffect(() => {
+    setThemeMounted(true);
+  }, []);
 
   const handleLogout = () => {
     clearAccessToken();
     clearStoredUserProfile();
     setIsAuthenticated(false);
     setUserName(null);
+    setIsOAuthUser(false);
   };
 
   const isActive = (path: string) => location.pathname === path;
   const navLinkBaseClass = 'text-[14px] font-medium transition-all duration-200 relative inline-block hover:scale-105';
+  const isDarkTheme = themeMounted && resolvedTheme === 'dark';
+  const themeToggleLabel = isDarkTheme ? '라이트 모드로 전환' : '다크 모드로 전환';
 
   return (
-    <header className="sticky top-0 z-50 bg-white/80 backdrop-blur-lg border-b border-[var(--border)]">
-      <div className="container mx-auto px-4 sm:px-6 h-16 flex items-center justify-between">
+    <header className="sticky top-0 z-50 bg-white/80 dark:bg-[rgba(8,13,23,0.78)] backdrop-blur-xl border-b border-[var(--border)] dark:border-[var(--border-subtle)]">
+      <div className="container mx-auto px-4 sm:px-6 h-[68px] flex items-center justify-between">
         <Link to="/" className="flex items-center gap-2 sm:gap-2.5 hover:opacity-80 transition-opacity group" aria-label="뱅고 홈">
           {/* Bengo Logo */}
           <div className="relative">
@@ -49,7 +61,7 @@ export function Header() {
             <div className="absolute -top-0.5 -right-0.5 sm:-top-1 sm:-right-1 w-2.5 h-2.5 sm:w-3 sm:h-3 bg-gradient-to-br from-amber-400 to-orange-500 rounded-full"></div>
           </div>
           <div className="flex flex-col">
-            <span className="text-[17px] sm:text-[19px] font-bold tracking-tight bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent leading-none">bengo</span>
+            <span className="text-[17px] sm:text-[19px] font-extrabold tracking-tight bg-gradient-to-r from-blue-600 to-purple-600 dark:from-[#60A5FA] dark:to-[#A78BFA] bg-clip-text text-transparent leading-none">bengo</span>
             <span className="text-[9px] sm:text-[10px] text-[var(--muted-foreground)] tracking-wide leading-none mt-0.5">benefit + go</span>
           </div>
         </Link>
@@ -105,6 +117,15 @@ export function Header() {
         </nav>
 
         <div className="flex items-center gap-3">
+          <button
+            type="button"
+            aria-label={themeToggleLabel}
+            title={themeToggleLabel}
+            className="flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--card)] dark:bg-[rgba(15,23,42,0.6)] text-[var(--foreground)] transition-colors hover:bg-[var(--muted)] hover:text-[var(--accent)] dark:hover:bg-[rgba(30,41,59,0.78)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/30"
+            onClick={() => setTheme(isDarkTheme ? 'light' : 'dark')}
+          >
+            {isDarkTheme ? <Sun className="h-4 w-4" aria-hidden="true" /> : <Moon className="h-4 w-4" aria-hidden="true" />}
+          </button>
           {isAuthenticated && (
             <div className="hidden sm:block">
               <NotificationButton />
@@ -128,12 +149,22 @@ export function Header() {
                   <p className="text-xs font-normal text-[var(--muted-foreground)]">계정 메뉴</p>
                 </DropdownMenuLabel>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem asChild className="cursor-pointer rounded-lg px-3 py-2.5">
-                  <Link to="/profile?tab=password">
+                {isOAuthUser ? (
+                  <DropdownMenuItem
+                    disabled
+                    className="cursor-not-allowed rounded-lg px-3 py-2.5"
+                  >
                     <LockKeyhole className="h-4 w-4" aria-hidden="true" />
                     비밀번호 변경
-                  </Link>
-                </DropdownMenuItem>
+                  </DropdownMenuItem>
+                ) : (
+                  <DropdownMenuItem asChild className="cursor-pointer rounded-lg px-3 py-2.5">
+                    <Link to="/profile?tab=password">
+                      <LockKeyhole className="h-4 w-4" aria-hidden="true" />
+                      비밀번호 변경
+                    </Link>
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem asChild className="cursor-pointer rounded-lg px-3 py-2.5">
                   <Link to="/profile?tab=withdraw">
                     <ShieldAlert className="h-4 w-4" aria-hidden="true" />

--- a/frontend/src/app/components/organisms/MatchSummaryCard.tsx
+++ b/frontend/src/app/components/organisms/MatchSummaryCard.tsx
@@ -19,7 +19,9 @@ type EditField = 'age' | 'region' | 'interests' | null;
 
 const interestLabels: Record<string, string> = {
   youth_policy: '청년정책',
-  childcare_policy: '육아/보육',
+  childcare_policy: '육아정책',
+  senior_policy: '노인정책',
+  disability_policy: '장애인정책',
 };
 
 export function MatchSummaryCard({
@@ -64,8 +66,8 @@ export function MatchSummaryCard({
 
   return (
     <div className="relative">
-      <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-4 relative overflow-hidden">
-        <div className="absolute top-0 right-0 w-32 h-32 bg-gradient-to-bl from-blue-50 via-purple-50/30 to-transparent rounded-full blur-2xl opacity-60"></div>
+      <div className="bg-white dark:bg-[rgba(15,23,42,0.72)] dark:backdrop-blur-xl rounded-2xl border border-gray-200 dark:border-[var(--border-default)] shadow-sm dark:shadow-[0_18px_48px_rgba(0,0,0,0.22)] p-4 relative overflow-hidden">
+        <div className="absolute top-0 right-0 w-32 h-32 bg-gradient-to-bl from-blue-50 via-purple-50/30 to-transparent dark:from-[rgba(59,130,246,0.18)] dark:via-[rgba(139,92,246,0.12)] dark:to-transparent rounded-full blur-2xl opacity-60"></div>
 
         <div className="relative z-10">
           <div className="mb-3">
@@ -79,7 +81,7 @@ export function MatchSummaryCard({
               </span>
             </div>
 
-            <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
+            <div className="h-1.5 bg-gray-100 dark:bg-[rgba(148,163,184,0.18)] rounded-full overflow-hidden">
               <div
                 className="h-full bg-gradient-to-r from-[var(--accent)] via-blue-500 to-purple-600 transition-all duration-500 ease-out rounded-full relative overflow-hidden"
                 style={{ width: `${completionPercentage}%` }}
@@ -103,7 +105,7 @@ export function MatchSummaryCard({
           </div>
 
           {isYouth && (
-            <div className="flex items-center gap-1.5 px-2.5 py-2 rounded-xl bg-gradient-to-r from-blue-50 to-purple-50 border border-blue-200/50">
+            <div className="flex items-center gap-1.5 px-2.5 py-2 rounded-xl bg-gradient-to-r from-blue-50 to-purple-50 dark:from-[rgba(59,130,246,0.10)] dark:to-[rgba(139,92,246,0.10)] border border-blue-200/50 dark:border-[rgba(96,165,250,0.22)]">
               <div className="w-5 h-5 rounded-lg bg-gradient-to-br from-[var(--accent)] to-purple-600 flex items-center justify-center flex-shrink-0">
                 <Sparkles className="w-3 h-3 text-white" />
               </div>

--- a/frontend/src/app/components/organisms/PolicyCard.tsx
+++ b/frontend/src/app/components/organisms/PolicyCard.tsx
@@ -78,7 +78,7 @@ function BadgeRow({ badges }: { badges: BadgeItem[] }) {
       )}
       {tooltipPos && hiddenBadges.length > 0 && createPortal(
         <div
-          className="fixed flex flex-col gap-1.5 bg-white border border-[var(--border)] rounded-xl px-3 py-2.5 shadow-lg z-[9999] pointer-events-none whitespace-nowrap"
+          className="fixed flex flex-col gap-1.5 bg-white dark:bg-[rgba(15,23,42,0.95)] dark:backdrop-blur-xl border border-[var(--border)] dark:border-[var(--border-default)] rounded-xl px-3 py-2.5 shadow-lg z-[9999] pointer-events-none whitespace-nowrap"
           style={{ left: tooltipPos.x, top: tooltipPos.y, transform: 'translateY(-50%)' }}
         >
           {hiddenBadges.map(b => <span key={b.key}>{b.el}</span>)}
@@ -163,6 +163,8 @@ export function PolicyCard({
   periodRaw,
   fitScore,
   categories = [],
+  policyType,
+  sourceType,
   bookmarked,
   onBookmark,
   className,
@@ -171,6 +173,15 @@ export function PolicyCard({
   const location = useLocation();
   const [isBookmarkAnimating, setIsBookmarkAnimating] = useState(false);
   const status = getDisplayStatus(applicationStatus, endsAt, isAlwaysOpen);
+  const policyCardStatus = status === 'recruiting'
+    ? 'open'
+    : status === 'always'
+      ? 'always'
+      : status === 'closed'
+        ? 'closed'
+        : periodRaw
+          ? 'check'
+          : 'unknown';
   const eligibility = getEligibility(fitScore ?? null);
   const urgentDeadlineLabel = status === 'recruiting' ? getUrgentDeadlineLabel(endsAt) : null;
 
@@ -194,11 +205,20 @@ export function PolicyCard({
     }
   };
 
-  const statusLabels = {
-    recruiting: '모집중',
+  const policyStatusLabels = {
+    open: '모집중',
     always: '상시',
+    check: '정책별 확인',
+    unknown: '기간확인불가',
     closed: '마감',
-  };
+  } as const;
+  const policyStatusVariants = {
+    open: 'recruiting',
+    always: 'always',
+    check: 'default',
+    unknown: 'default',
+    closed: 'closed',
+  } as const;
 
   const eligibilityLabels = {
     eligible: '가능성 높음',
@@ -211,21 +231,38 @@ export function PolicyCard({
     needsReview: 'needsReview' as const,
     infoLacking: 'default' as const,
   };
-  
+
   const categoryLabels: Record<string, string> = {
     youth_policy: '청년정책',
     childcare_policy: '육아정책',
+    senior_policy: '노인정책',
+    disability_policy: '장애인정책',
   };
+
+  const policyTypeLabels = {
+    application: '신청형',
+    info: '정보형',
+  } as const;
+
+  const sourceTypeLabels = {
+    official: '공식',
+    blog: '비공식',
+    none: '출처없음',
+  } as const;
 
   return (
     <Link to={`/policies/${id}`} className="block h-full cursor-pointer" onClick={handleCardClick}>
       <article
+        data-policy-card
+        data-policy-status={policyCardStatus}
+        data-policy-urgent={urgentDeadlineLabel ? 'true' : undefined}
         className={cn(
-          'group relative border rounded-3xl p-6 sm:p-8 h-full flex flex-col',
+          'group relative border rounded-2xl p-5 sm:p-7 h-full flex flex-col',
           'shadow-sm hover:shadow-xl',
+          'dark:bg-[rgba(15,23,42,0.72)] dark:backdrop-blur-md dark:shadow-[0_18px_48px_rgba(0,0,0,0.22)] dark:hover:bg-[rgba(30,41,59,0.86)] dark:hover:shadow-[0_24px_60px_rgba(0,0,0,0.32)]',
           status ? borderColors[status] : periodRaw ? 'border-[#00D9D9] hover:border-[#00BDBD] hover:shadow-[#00FFFF]/25 bg-[#00FFFF]/10' : 'border-amber-500 hover:border-amber-600 hover:shadow-amber-500/25 bg-amber-50/60',
           urgentDeadlineLabel && 'border-red-500 hover:border-red-600',
-          'hover:-translate-y-2',
+          'hover:-translate-y-1',
           'transition-all duration-300 ease-out',
           className
         )}
@@ -243,8 +280,21 @@ export function PolicyCard({
               {title}
             </h3>
             <BadgeRow badges={[
-              ...(status ? [{ key: 'status', label: statusLabels[status], el: <Badge variant={status}>{statusLabels[status]}</Badge> }] : []),
+              {
+                key: 'status',
+                label: policyStatusLabels[policyCardStatus],
+                el: (
+                  <Badge
+                    variant={policyStatusVariants[policyCardStatus]}
+                    className={`policy-status-badge status-${policyCardStatus}`}
+                  >
+                    {policyStatusLabels[policyCardStatus]}
+                  </Badge>
+                ),
+              },
               { key: 'provider', label: providerName, el: <Badge variant="default"><span className="max-w-[120px] truncate block">{providerName}</span></Badge> },
+              ...(policyType ? [{ key: `type-${policyType}`, label: policyTypeLabels[policyType], el: <Badge variant="default" className={policyType === 'application' ? 'bg-violet-50 text-violet-700 border-violet-200' : 'bg-orange-50 text-orange-700 border-orange-200'}>{policyTypeLabels[policyType]}</Badge> }] : []),
+              ...(sourceType ? [{ key: `source-${sourceType}`, label: sourceTypeLabels[sourceType], el: <Badge variant="default" className={sourceType === 'official' ? 'bg-emerald-50 text-emerald-700 border-emerald-200' : sourceType === 'blog' ? 'bg-amber-50 text-amber-700 border-amber-200' : 'bg-slate-50 text-slate-700 border-slate-200'}>{sourceTypeLabels[sourceType]}</Badge> }] : []),
               ...categories.map((c) => ({ key: c, label: categoryLabels[c] || c, el: <Badge variant="default" className="bg-blue-50 text-blue-700 border-blue-200">{categoryLabels[c] || c}</Badge> })),
               ...(eligibility ? [{ key: 'eligibility', label: eligibilityLabels[eligibility], el: <Badge variant={eligibilityVariants[eligibility]}>{eligibilityLabels[eligibility]}</Badge> }] : []),
             ]} />
@@ -252,7 +302,7 @@ export function PolicyCard({
           {onBookmark && (
             <motion.button
               onClick={handleBookmarkClick}
-              className="flex-shrink-0 p-2.5 hover:bg-[var(--muted)] rounded-xl transition-all duration-200 cursor-pointer"
+              className="flex-shrink-0 p-2.5 hover:bg-[var(--muted)] dark:hover:bg-[rgba(30,41,59,0.6)] rounded-xl transition-all duration-200 cursor-pointer"
               aria-label={bookmarked ? '저장 취소' : '정책 저장'}
               aria-pressed={bookmarked}
               whileTap={{ scale: 0.9 }}

--- a/frontend/src/app/components/organisms/ProfileEditDialog.tsx
+++ b/frontend/src/app/components/organisms/ProfileEditDialog.tsx
@@ -22,10 +22,13 @@ interface ProfileEditDialogProps {
 }
 
 const REGION_OPTIONS = ['서울'];
+const MAX_INTERESTS = 2;
 
 const INTEREST_OPTIONS = [
   { value: 'youth_policy', label: '청년정책' },
-  { value: 'childcare_policy', label: '육아/보육정책' },
+  { value: 'childcare_policy', label: '육아정책' },
+  { value: 'senior_policy', label: '노인정책' },
+  { value: 'disability_policy', label: '장애인정책' },
 ];
 
 const fieldConfig = {
@@ -69,13 +72,19 @@ export function ProfileEditDialog({
     setSelectedInterests((prev) =>
       prev.includes(interestValue)
         ? prev.filter((i) => i !== interestValue)
+        : prev.length >= MAX_INTERESTS
+        ? prev
         : [...prev, interestValue],
     );
   };
 
   const handleSave = () => {
     if (field === 'interests') {
-      onSave(JSON.stringify(selectedInterests));
+      onSave(JSON.stringify(
+        selectedInterests
+          .filter((interest) => INTEREST_OPTIONS.some((option) => option.value === interest))
+          .slice(0, MAX_INTERESTS),
+      ));
     } else {
       onSave(value);
     }
@@ -126,6 +135,7 @@ export function ProfileEditDialog({
 
             {field === 'interests' && (
               <div className="flex flex-col gap-2">
+                <p className="text-xs text-[var(--muted-foreground)]">최대 {MAX_INTERESTS}개까지 선택할 수 있어요.</p>
                 {INTEREST_OPTIONS.map((option) => {
                   const isSelected = selectedInterests.includes(option.value);
                   return (
@@ -152,7 +162,8 @@ export function ProfileEditDialog({
                           </svg>
                         )}
                       </div>
-                      {option.label}
+                      <span className="flex-1">{option.label}</span>
+                      <span className="text-xs text-[var(--muted-foreground)]">선택 가능</span>
                     </button>
                   );
                 })}

--- a/frontend/src/app/pages/CheckEmailPage.tsx
+++ b/frontend/src/app/pages/CheckEmailPage.tsx
@@ -1,10 +1,36 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
-import { ArrowRight, MailCheck } from 'lucide-react';
+import { ArrowRight, CheckCircle2, MailCheck } from 'lucide-react';
 import { toast } from 'sonner';
 import { resendVerification } from '../api/auth';
 import { ApiClientError, getStoredUserProfile } from '../api/client';
 import { Button } from '../components/atoms/Button';
+
+const EMAIL_VERIFIED_EVENT_KEY = 'bengo:email-verified';
+
+type EmailVerificationMessage = {
+  status?: string;
+};
+
+function parseEmailVerificationMessage(value: unknown): EmailVerificationMessage | null {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value) as EmailVerificationMessage;
+    } catch {
+      return null;
+    }
+  }
+
+  if (typeof value === 'object' && 'status' in value) {
+    return value as EmailVerificationMessage;
+  }
+
+  return null;
+}
 
 export function CheckEmailPage() {
   const navigate = useNavigate();
@@ -12,8 +38,67 @@ export function CheckEmailPage() {
   const storedUser = getStoredUserProfile();
   const email = searchParams.get('email') ?? storedUser?.email ?? '';
   const [loading, setLoading] = useState(false);
+  const [cooldown, setCooldown] = useState(0);
+  const [verified, setVerified] = useState(false);
+
+  useEffect(() => {
+    if (cooldown <= 0) {
+      return;
+    }
+
+    const timerId = window.setTimeout(() => {
+      setCooldown((current) => Math.max(0, current - 1));
+    }, 1000);
+
+    return () => window.clearTimeout(timerId);
+  }, [cooldown]);
+
+  useEffect(() => {
+    let handled = false;
+
+    const handleVerified = () => {
+      if (handled) {
+        return;
+      }
+
+      handled = true;
+      setVerified(true);
+      toast.success('이메일 인증이 완료되었습니다. 인증 탭에서 로그인해주세요.');
+    };
+
+    const handleStorage = (event: StorageEvent) => {
+      const message = parseEmailVerificationMessage(event.newValue);
+      if (event.key === EMAIL_VERIFIED_EVENT_KEY && message?.status === 'success') {
+        handleVerified();
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+
+    let channel: BroadcastChannel | null = null;
+    try {
+      channel = new BroadcastChannel(EMAIL_VERIFIED_EVENT_KEY);
+      channel.onmessage = (event) => {
+        const message = parseEmailVerificationMessage(event.data);
+        if (message?.status === 'success') {
+          handleVerified();
+        }
+      };
+    } catch {
+      channel = null;
+    }
+
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+      channel?.close();
+    };
+  }, []);
 
   const handleResend = async () => {
+    if (cooldown > 0) {
+      return;
+    }
+
     if (!email) {
       toast.error('이메일 정보가 없습니다. 다시 회원가입 또는 로그인해주세요.');
       return;
@@ -22,6 +107,7 @@ export function CheckEmailPage() {
     setLoading(true);
     try {
       await resendVerification(email);
+      setCooldown(60);
       toast.success('인증 메일을 다시 보냈습니다.');
     } catch (error) {
       const message = error instanceof ApiClientError ? error.message : '인증 메일 재발송에 실패했습니다.';
@@ -50,23 +136,50 @@ export function CheckEmailPage() {
         </div>
 
         <div className="bg-white rounded-2xl shadow-lg p-8 text-center">
-          <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-50 text-[var(--accent)]">
-            <MailCheck className="h-7 w-7" aria-hidden="true" />
+          <div className={`mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl ${verified ? 'bg-emerald-50 text-emerald-600' : 'bg-blue-50 text-[var(--accent)]'}`}>
+            {verified ? <CheckCircle2 className="h-7 w-7" aria-hidden="true" /> : <MailCheck className="h-7 w-7" aria-hidden="true" />}
           </div>
-          <h1 className="text-xl font-bold text-[var(--foreground)]">인증 메일을 확인해주세요</h1>
+          <h1 className="text-xl font-bold text-[var(--foreground)]">
+            {verified ? '이메일 인증이 완료되었습니다' : '이메일 인증이 필요합니다'}
+          </h1>
           <p className="mt-3 text-sm leading-relaxed text-[var(--muted-foreground)]">
-            {email ? <><span className="font-medium text-[var(--foreground)]">{email}</span>로 인증 링크를 보냈습니다.</> : '가입한 이메일로 인증 링크를 보냈습니다.'}
-            <br />
-            링크를 눌러야 자격확인, 정책 저장, MY 기능을 이용할 수 있어요.
+            {verified ? (
+              <>
+                메일 링크로 열린 탭에서 로그인 화면으로 이동합니다.
+                <br />
+                이 탭은 닫아도 됩니다.
+              </>
+            ) : (
+              <>
+                {email ? <><span className="font-medium text-[var(--foreground)]">{email}</span>로 인증 링크를 보냈습니다.</> : '가입한 이메일로 인증 링크를 보냈습니다.'}
+                <br />
+                메일의 인증 링크를 눌러야 회원가입이 완료됩니다.
+              </>
+            )}
           </p>
 
           <div className="mt-7 space-y-3">
-            <Button type="button" className="w-full" onClick={() => navigate('/login')}>
-              로그인하러 가기
-            </Button>
-            <Button type="button" variant="secondary" className="w-full" loading={loading} onClick={handleResend}>
-              인증 메일 재발송
-            </Button>
+            {verified ? (
+              <Button type="button" className="w-full" onClick={() => navigate('/login')}>
+                로그인하기
+              </Button>
+            ) : (
+              <>
+                <Button type="button" className="w-full" onClick={() => navigate('/login')}>
+                  인증 후 로그인하기
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="w-full"
+                  loading={loading}
+                  disabled={cooldown > 0}
+                  onClick={handleResend}
+                >
+                  {cooldown > 0 ? `인증 메일 재발송 ${cooldown}초` : '인증 메일 재발송'}
+                </Button>
+              </>
+            )}
             <Link to="/policies" className="block text-sm text-[var(--muted-foreground)] hover:text-[var(--accent)]">
               가입 없이 정책 둘러보기
             </Link>

--- a/frontend/src/app/pages/EmailVerifiedPage.tsx
+++ b/frontend/src/app/pages/EmailVerifiedPage.tsx
@@ -2,6 +2,9 @@ import { useEffect } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 import { ArrowRight, CheckCircle2, CircleAlert, Clock } from 'lucide-react';
 import { Button } from '../components/atoms/Button';
+import { getEmailVerificationUrl } from '../api/auth';
+
+const EMAIL_VERIFIED_EVENT_KEY = 'bengo:email-verified';
 
 const statusContent = {
   success: {
@@ -24,18 +27,47 @@ const statusContent = {
   },
 };
 
+function notifyEmailVerified() {
+  const payload = { status: 'success', at: Date.now() };
+
+  try {
+    window.localStorage.setItem(EMAIL_VERIFIED_EVENT_KEY, JSON.stringify(payload));
+  } catch {
+    // Ignore storage failures so the verified tab can still move to login.
+  }
+
+  try {
+    const channel = new BroadcastChannel(EMAIL_VERIFIED_EVENT_KEY);
+    channel.postMessage(payload);
+    channel.close();
+  } catch {
+    // BroadcastChannel is optional; localStorage still covers normal browser tabs.
+  }
+}
+
 export function EmailVerifiedPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
   const rawStatus = searchParams.get('status') ?? 'invalid';
   const status = rawStatus in statusContent ? rawStatus as keyof typeof statusContent : 'invalid';
   const content = statusContent[status];
   const Icon = content.icon;
 
   useEffect(() => {
+    if (!token || searchParams.has('status')) {
+      return;
+    }
+
+    window.location.replace(getEmailVerificationUrl(token));
+  }, [searchParams, token]);
+
+  useEffect(() => {
     if (status !== 'success') {
       return;
     }
+
+    notifyEmailVerified();
 
     const timeoutId = window.setTimeout(() => {
       navigate('/login', { replace: true });
@@ -43,6 +75,22 @@ export function EmailVerifiedPage() {
 
     return () => window.clearTimeout(timeoutId);
   }, [navigate, status]);
+
+  if (token && !searchParams.has('status')) {
+    return (
+      <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center px-4 py-8 sm:py-12">
+        <div className="w-full max-w-md rounded-2xl bg-white p-8 text-center shadow-lg">
+          <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-50 text-blue-600">
+            <Clock className="h-7 w-7 animate-pulse" aria-hidden="true" />
+          </div>
+          <h1 className="text-xl font-bold text-[var(--foreground)]">이메일 인증 확인 중입니다</h1>
+          <p className="mt-3 text-sm leading-relaxed text-[var(--muted-foreground)]">
+            인증 링크를 확인하고 있어요. 잠시만 기다려주세요.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center px-4 py-8 sm:py-12">

--- a/frontend/src/app/pages/HomePage.tsx
+++ b/frontend/src/app/pages/HomePage.tsx
@@ -15,12 +15,21 @@ export function HomePage() {
     <MainLayout>
       <div ref={containerRef}>
         {/* Hero Section */}
-        <section className="min-h-[90vh] flex items-center justify-center bg-gradient-to-b from-slate-50 to-white relative overflow-hidden px-4 pt-20 pb-16">
+        <section className="min-h-[90vh] flex items-center justify-center bg-gradient-to-b from-slate-50 to-white dark:bg-none dark:bg-[var(--bg-hero)] relative overflow-hidden px-4 pt-20 pb-16">
+          {/* Dark-mode radial glow */}
+          <div
+            aria-hidden="true"
+            className="hidden dark:block absolute inset-0 pointer-events-none"
+            style={{
+              backgroundImage:
+                'radial-gradient(circle at 50% 28%, rgba(59,130,246,0.18), transparent 38%), radial-gradient(circle at 50% 44%, rgba(139,92,246,0.14), transparent 42%)',
+            }}
+          ></div>
           {/* CSS Grid Pattern Background */}
-          <div className="absolute inset-0 opacity-[0.4]" style={{
+          <div className="absolute inset-0 opacity-[0.4] dark:opacity-[0.18]" style={{
             backgroundImage: `
-              linear-gradient(to right, rgb(226, 232, 240) 1px, transparent 1px),
-              linear-gradient(to bottom, rgb(226, 232, 240) 1px, transparent 1px)
+              linear-gradient(to right, color-mix(in srgb, var(--muted-foreground) 24%, transparent) 1px, transparent 1px),
+              linear-gradient(to bottom, color-mix(in srgb, var(--muted-foreground) 24%, transparent) 1px, transparent 1px)
             `,
             backgroundSize: '40px 40px'
           }}></div>
@@ -168,7 +177,7 @@ export function HomePage() {
         </section>
 
         {/* Feature 1: 검색 */}
-        <section className="min-h-screen flex items-center justify-center bg-white relative overflow-hidden py-20">
+        <section className="min-h-screen flex items-center justify-center bg-white dark:bg-[#080E18] relative overflow-hidden py-20">
           <div className="container mx-auto max-w-6xl px-4">
             <div className="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
               <motion.div
@@ -302,7 +311,7 @@ export function HomePage() {
         </section>
 
         {/* Feature 2: 자격 확인 */}
-        <section className="min-h-screen flex items-center justify-center bg-slate-50 relative overflow-hidden py-20">
+        <section className="min-h-screen flex items-center justify-center bg-slate-50 dark:bg-[#0A101B] relative overflow-hidden py-20">
           <div className="container mx-auto max-w-6xl px-4">
             <div className="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
               <motion.div
@@ -428,7 +437,7 @@ export function HomePage() {
         </section>
 
         {/* Feature 3: 저장 & 알림 */}
-        <section className="min-h-screen flex items-center justify-center bg-white relative overflow-hidden py-20">
+        <section className="min-h-screen flex items-center justify-center bg-white dark:bg-[#080E18] relative overflow-hidden py-20">
           <div className="container mx-auto max-w-6xl px-4">
             <div className="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
               <motion.div
@@ -473,20 +482,20 @@ export function HomePage() {
                 className="relative"
               >
                 {/* Mock UI - MY 페이지 / 저장한 정책 (MyPage 히어로 최대한 반영) */}
-                <div className="bg-gradient-to-br from-slate-50 to-white rounded-2xl shadow-2xl overflow-hidden border border-gray-200 h-[480px] flex flex-col">
+                <div className="bg-gradient-to-br from-slate-50 to-white dark:bg-none dark:bg-[#0F172A] rounded-2xl shadow-2xl dark:shadow-[0_20px_60px_rgba(0,0,0,0.25)] overflow-hidden border border-gray-200 dark:border-[var(--border-default)] h-[480px] flex flex-col">
                   {/* Browser chrome */}
-                  <div className="bg-white px-4 py-3 border-b border-gray-200 flex items-center gap-2">
+                  <div className="bg-white dark:bg-[#0A101B] px-4 py-3 border-b border-gray-200 dark:border-[var(--border-default)] flex items-center gap-2">
                     <div className="flex gap-1.5">
                       <div className="w-3 h-3 rounded-full bg-red-400"></div>
                       <div className="w-3 h-3 rounded-full bg-yellow-400"></div>
                       <div className="w-3 h-3 rounded-full bg-green-400"></div>
                     </div>
-                    <div className="bg-gray-100 rounded px-3 py-1 text-xs text-gray-500 ml-2">bengo.com/me</div>
+                    <div className="bg-gray-100 dark:bg-[var(--surface-2)] rounded px-3 py-1 text-xs text-gray-500 dark:text-[var(--text-muted)] ml-2">bengo.com/me</div>
                   </div>
 
                   {/* MY 페이지 히어로 (실제 MyPage.tsx 3열 구조 재현) */}
-                  <div className="bg-gradient-to-b from-blue-50 to-white px-3 py-3">
-                    <div className="bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 border border-blue-100 rounded-xl shadow-sm p-2.5">
+                  <div className="bg-gradient-to-b from-blue-50 to-white dark:bg-none dark:bg-[var(--bg-main)] px-3 py-3">
+                    <div className="bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 border border-blue-100 shadow-sm dark:bg-none dark:bg-[rgba(15,23,42,0.72)] dark:border-[var(--border-default)] dark:shadow-[0_20px_60px_rgba(0,0,0,0.25)] dark:backdrop-blur-xl rounded-xl p-2.5">
                       <div className="grid grid-cols-[minmax(0,1.1fr)_minmax(0,1.35fr)_auto] gap-2 items-center">
                         {/* Col 1: 프로필 */}
                         <div className="flex items-start gap-2">
@@ -507,17 +516,17 @@ export function HomePage() {
 
                         {/* Col 2: 통계 3박스 */}
                         <div className="grid grid-cols-3 gap-1">
-                          <div className="bg-white/70 border border-white/80 rounded-lg px-1.5 py-1 shadow-sm">
+                          <div className="bg-white/70 dark:bg-[rgba(15,23,42,0.58)] backdrop-blur-sm border border-white/80 dark:border-[var(--border-default)] rounded-lg px-1.5 py-1 shadow-sm">
                             <div className="text-[8px] font-medium text-gray-500 leading-tight">저장한 정책</div>
                             <div className="text-[14px] font-semibold text-gray-900 leading-tight mt-0.5">4</div>
                             <div className="text-[7.5px] text-gray-400 leading-tight mt-0.5">전체 저장</div>
                           </div>
-                          <div className="bg-white/70 border border-white/80 rounded-lg px-1.5 py-1 shadow-sm">
+                          <div className="bg-white/70 dark:bg-[rgba(15,23,42,0.58)] backdrop-blur-sm border border-white/80 dark:border-[var(--border-default)] rounded-lg px-1.5 py-1 shadow-sm">
                             <div className="text-[8px] font-medium text-gray-500 leading-tight">모집중</div>
                             <div className="text-[14px] font-semibold text-emerald-600 leading-tight mt-0.5">4</div>
                             <div className="text-[7.5px] text-gray-400 leading-tight mt-0.5">신청 가능</div>
                           </div>
-                          <div className="bg-white/70 border border-white/80 rounded-lg px-1.5 py-1 shadow-sm">
+                          <div className="bg-white/70 dark:bg-[rgba(15,23,42,0.58)] backdrop-blur-sm border border-white/80 dark:border-[var(--border-default)] rounded-lg px-1.5 py-1 shadow-sm">
                             <div className="text-[8px] font-medium text-gray-500 leading-tight">관심사</div>
                             <div className="mt-1">
                               <span className="inline-block text-[8px] font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded px-1 leading-tight">청년정책</span>
@@ -526,7 +535,7 @@ export function HomePage() {
                         </div>
 
                         {/* Col 3: 링 + 프로필 수정 */}
-                        <div className="bg-white/75 border border-white/80 rounded-lg p-1.5 shadow-sm flex flex-col justify-between min-w-[96px]">
+                        <div className="bg-white/75 dark:bg-[rgba(15,23,42,0.62)] backdrop-blur-sm border border-white/80 dark:border-[var(--border-default)] rounded-lg p-1.5 shadow-sm flex flex-col justify-between min-w-[96px]">
                           <div className="flex items-center gap-1.5">
                             <div className="relative h-9 w-9 flex-shrink-0">
                               <svg className="h-9 w-9 -rotate-90" viewBox="0 0 36 36" aria-hidden="true">
@@ -555,8 +564,8 @@ export function HomePage() {
                             </div>
                             <div className="text-[9px] font-semibold text-gray-700 leading-tight">프로필<br />완성도</div>
                           </div>
-                          <div className="mt-1.5 pt-1.5 border-t border-blue-100/80">
-                            <div className="flex items-center justify-center gap-1 bg-white border border-gray-200 rounded text-[9px] text-gray-700 font-medium py-1 px-1.5">
+                          <div className="mt-1.5 pt-1.5 border-t border-blue-100/80 dark:border-[var(--border-subtle)]">
+                            <div className="flex items-center justify-center gap-1 bg-white dark:bg-[rgba(15,23,42,0.58)] border border-gray-200 dark:border-[var(--border-default)] rounded text-[9px] text-gray-700 dark:text-[var(--text-secondary)] font-medium py-1 px-1.5">
                               <Edit className="h-2 w-2" />
                               <span>프로필 수정</span>
                             </div>
@@ -567,11 +576,11 @@ export function HomePage() {
                   </div>
 
                   {/* 상태 탭 (전체 / 예정 / 모집중 / 마감) */}
-                  <div className="bg-white mx-3 mb-2 rounded-xl px-1.5 py-1.5 flex items-center gap-1 border border-gray-100">
+                  <div className="bg-white dark:bg-[rgba(15,23,42,0.6)] mx-3 mb-2 rounded-xl px-1.5 py-1.5 flex items-center gap-1 border border-gray-100 dark:border-[var(--border-subtle)]">
                     <div className="text-[10px] font-medium px-2.5 py-1 rounded-lg bg-[var(--accent)] text-white">전체</div>
-                    <div className="text-[10px] font-medium px-2.5 py-1 rounded-lg text-gray-600">예정</div>
-                    <div className="text-[10px] font-medium px-2.5 py-1 rounded-lg text-gray-600">모집중</div>
-                    <div className="text-[10px] font-medium px-2.5 py-1 rounded-lg text-gray-600">마감</div>
+                    <div className="text-[10px] font-medium px-2.5 py-1 rounded-lg text-gray-600 dark:text-[var(--text-muted)]">예정</div>
+                    <div className="text-[10px] font-medium px-2.5 py-1 rounded-lg text-gray-600 dark:text-[var(--text-muted)]">모집중</div>
+                    <div className="text-[10px] font-medium px-2.5 py-1 rounded-lg text-gray-600 dark:text-[var(--text-muted)]">마감</div>
                   </div>
 
                   {/* 저장 카드 리스트 — 2열 그리드, D-7 이하는 빨간 테두리 + 우측 상단 D-N */}
@@ -584,12 +593,12 @@ export function HomePage() {
                         { status: 'recruiting' as const, daysLeft: 18, deadline: '2026.05.10', title: '청년 전세보증금 대출', org: 'LH' },
                       ].map((item, i) => {
                         const urgent = item.daysLeft !== null && item.daysLeft <= 7;
-                        const bgClass = item.status === 'recruiting' ? 'bg-emerald-50/40' : 'bg-blue-50/40';
+                        const bgClass = item.status === 'recruiting' ? 'bg-emerald-50/40 dark:bg-[rgba(15,23,42,0.72)]' : 'bg-blue-50/40 dark:bg-[rgba(15,23,42,0.72)]';
                         const borderClass = urgent
-                          ? 'border-red-500'
+                          ? 'border-red-500 dark:border-[rgba(248,113,113,0.45)]'
                           : item.status === 'recruiting'
-                            ? 'border-emerald-500'
-                            : 'border-blue-500';
+                            ? 'border-emerald-500 dark:border-[var(--border-default)]'
+                            : 'border-blue-500 dark:border-[var(--border-default)]';
                         const statusChipClass = item.status === 'recruiting'
                           ? 'bg-emerald-100 text-emerald-700'
                           : 'bg-blue-100 text-blue-700';
@@ -604,7 +613,7 @@ export function HomePage() {
                               <div className={`text-[9px] font-semibold px-1 py-0.5 rounded ${statusChipClass}`}>
                                 {item.status === 'recruiting' ? '모집중' : '상시'}
                               </div>
-                              <div className="text-[9px] px-1 py-0.5 rounded bg-white border border-gray-200 text-gray-600 truncate max-w-[64px]">{item.org}</div>
+                              <div className="text-[9px] px-1 py-0.5 rounded bg-white dark:bg-[rgba(15,23,42,0.58)] border border-gray-200 dark:border-[var(--border-default)] text-gray-600 dark:text-[var(--text-muted)] truncate max-w-[64px]">{item.org}</div>
                             </div>
                             <div className={`text-[11px] font-semibold text-gray-800 leading-snug mb-1 line-clamp-2 min-h-[28px] ${urgent ? 'pr-8' : ''}`}>
                               {item.title}
@@ -635,10 +644,10 @@ export function HomePage() {
         <FAQ />
 
         {/* CTA Section */}
-        <section className="pt-24 py-20 bg-gradient-to-br from-blue-100 via-purple-100 to-blue-100 relative overflow-hidden px-4">
-          <div className="absolute inset-0 opacity-50">
-            <div className="absolute top-1/4 right-1/3 w-[500px] h-[500px] bg-gradient-to-br from-blue-300 to-blue-200 rounded-full blur-3xl"></div>
-            <div className="absolute bottom-1/4 left-1/3 w-[500px] h-[500px] bg-gradient-to-br from-purple-300 to-purple-200 rounded-full blur-3xl"></div>
+        <section className="pt-24 py-20 bg-gradient-to-br from-blue-100 via-purple-100 to-blue-100 dark:from-[rgba(59,130,246,0.12)] dark:via-[rgba(139,92,246,0.10)] dark:to-[rgba(59,130,246,0.12)] dark:bg-[var(--bg-hero)] relative overflow-hidden px-4">
+          <div className="absolute inset-0 opacity-50 dark:opacity-30">
+            <div className="absolute top-1/4 right-1/3 w-[500px] h-[500px] bg-gradient-to-br from-blue-300 to-blue-200 dark:from-blue-500/40 dark:to-blue-700/30 rounded-full blur-3xl"></div>
+            <div className="absolute bottom-1/4 left-1/3 w-[500px] h-[500px] bg-gradient-to-br from-purple-300 to-purple-200 dark:from-purple-500/40 dark:to-purple-700/30 rounded-full blur-3xl"></div>
           </div>
           
           <motion.div 

--- a/frontend/src/app/pages/LoginPage.tsx
+++ b/frontend/src/app/pages/LoginPage.tsx
@@ -46,11 +46,12 @@ export function LoginPage() {
           email: formData.email,
           password: formData.password,
         });
-        toast.success('로그인 성공!');
         if (!response.user.emailVerified) {
+          toast.info('이메일 인증 후 로그인할 수 있습니다.');
           navigate(getEmailVerificationPath(response.user.email));
           return;
         }
+        toast.success('로그인 성공!');
         navigate(response.user.profileCompleted ? '/policies' : '/onboarding');
       } catch (error) {
         const message = error instanceof ApiClientError ? error.message : '로그인에 실패했습니다';

--- a/frontend/src/app/pages/MyPage.tsx
+++ b/frontend/src/app/pages/MyPage.tsx
@@ -2,8 +2,9 @@ import { useEffect, useState } from 'react';
 import { User, MapPin, Sparkles, Edit, Trash2, X } from 'lucide-react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
+import { updateProfile } from '../api/auth';
 import { getPolicyDetail } from '../api/policies';
-import { ApiClientError, getEmailVerificationPath, getStoredUserProfile, isEmailVerificationRequiredError, setStoredUserProfile } from '../api/client';
+import { ApiClientError, getEmailVerificationPath, getStoredUserProfile, isEmailVerificationRequiredError } from '../api/client';
 import { getMyPolicies, removeMyPolicy } from '../api/me';
 import { MainLayout } from '../components/templates/MainLayout';
 import { Button } from '../components/atoms/Button';
@@ -29,6 +30,7 @@ interface UserProfileView {
 }
 
 interface EditFormState {
+  displayName: string;
   age: string;
   regionCode: string;
   interests: string[];
@@ -47,14 +49,18 @@ function calculateProfileCompletion(user: UserProfileSummary | null): number {
   return Math.round((completed / 3) * 100);
 }
 
-const INTEREST_OPTIONS: { value: string; label: string }[] = [
+const INTEREST_OPTIONS: { value: UserProfileSummary['interests'][number]; label: string }[] = [
   { value: 'youth_policy', label: '청년정책' },
-  { value: 'childcare_policy', label: '육아/보육정책' },
+  { value: 'childcare_policy', label: '육아정책' },
+  { value: 'senior_policy', label: '노인정책' },
+  { value: 'disability_policy', label: '장애인정책' },
 ];
 
 const interestLabels: Record<string, string> = {
   youth_policy: '청년정책',
   childcare_policy: '육아정책',
+  senior_policy: '노인정책',
+  disability_policy: '장애인정책',
 };
 
 function mapApplicationStatus(detail: PolicyDetail, state: MyPolicyItem['state']): SavedPolicy['applicationStatus'] {
@@ -98,7 +104,7 @@ function mapStoredUserToView(user: UserProfileSummary | null): UserProfileView |
   }
 
   return {
-    name: user.email.split('@')[0],
+    name: user.displayName || user.email.split('@')[0],
     age: user.age,
     region: formatRegionCode(user.regionCode),
     interests: user.interests.map((interest) => interestLabels[interest] ?? interest),
@@ -106,6 +112,7 @@ function mapStoredUserToView(user: UserProfileSummary | null): UserProfileView |
 }
 
 const PAGE_SIZE = 12;
+const MAX_INTERESTS = 2;
 
 export function MyPage() {
   const navigate = useNavigate();
@@ -120,11 +127,13 @@ export function MyPage() {
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [policyToDelete, setPolicyToDelete] = useState<string | null>(null);
   const [editProfileOpen, setEditProfileOpen] = useState(false);
+  const [editProfileLoading, setEditProfileLoading] = useState(false);
   const [user, setUser] = useState<UserProfileView | null>(mapStoredUserToView(getStoredUserProfile()));
   const [editForm, setEditForm] = useState<EditFormState>(() => {
     const stored = getStoredUserProfile();
     return {
-      age: stored?.age ? String(stored.age) : '',
+      displayName: stored?.displayName ?? '',
+      age: stored?.age != null ? String(stored.age) : '',
       regionCode: stored?.regionCode ?? '',
       interests: stored?.interests ?? [],
     };
@@ -214,7 +223,7 @@ export function MyPage() {
     closed: savedPolicies.filter((policy) => policy.applicationStatus === 'closed').length,
   };
 
-  const handleSaveProfile = () => {
+  const handleSaveProfile = async () => {
     const storedUser = getStoredUserProfile();
 
     if (!storedUser) {
@@ -222,18 +231,49 @@ export function MyPage() {
       return;
     }
 
-    const nextStoredUser = {
-      ...storedUser,
-      age: editForm.age ? Number(editForm.age) : storedUser.age,
-      regionCode: (editForm.regionCode || storedUser.regionCode) as typeof storedUser.regionCode,
-      interests: editForm.interests.length > 0 ? editForm.interests as typeof storedUser.interests : storedUser.interests,
-      profileCompleted: true,
-    };
+    const age = editForm.age ? Number(editForm.age) : undefined;
+    if (age !== undefined && (!Number.isInteger(age) || age < 14 || age > 120)) {
+      toast.error('나이는 14세 이상 120세 이하로 입력해주세요.');
+      return;
+    }
 
-    setStoredUserProfile(nextStoredUser);
-    setUser(mapStoredUserToView(nextStoredUser));
-    setEditProfileOpen(false);
-    toast.success('프로필이 저장되었습니다');
+    const interests = editForm.interests
+      .filter((interest) => INTEREST_OPTIONS.some((option) => option.value === interest)) as typeof storedUser.interests;
+    if (interests.length === 0) {
+      toast.error('관심사를 1개 이상 선택해주세요.');
+      return;
+    }
+    if (interests.length > MAX_INTERESTS) {
+      toast.error(`관심사는 최대 ${MAX_INTERESTS}개까지 선택할 수 있습니다.`);
+      return;
+    }
+    const regionCode = (editForm.regionCode || storedUser.regionCode || undefined) as
+      | NonNullable<UserProfileSummary['regionCode']>
+      | undefined;
+
+    setEditProfileLoading(true);
+    try {
+      const response = await updateProfile({
+        displayName: editForm.displayName.trim() || undefined,
+        age,
+        regionCode,
+        interests,
+      });
+
+      setUser(mapStoredUserToView(response.user));
+      setEditProfileOpen(false);
+      setReloadKey((current) => current + 1);
+      toast.success('프로필이 저장되었습니다');
+    } catch (error) {
+      if (isEmailVerificationRequiredError(error)) {
+        navigate(getEmailVerificationPath(storedUser.email));
+        return;
+      }
+      const message = error instanceof ApiClientError ? error.message : '프로필 저장에 실패했습니다';
+      toast.error(message);
+    } finally {
+      setEditProfileLoading(false);
+    }
   };
 
   const handleRetry = () => {
@@ -248,13 +288,13 @@ export function MyPage() {
 
   return (
     <MainLayout>
-      <div className="bg-gradient-to-b from-blue-50 to-white py-8 sm:py-10 md:py-12">
-        <div className="container mx-auto px-4">
-          <div className="bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 border border-blue-100 rounded-2xl shadow-lg p-6 md:p-8 mb-6 md:mb-8">
+      <div className="bg-gradient-to-b from-blue-50 to-white dark:bg-none dark:bg-[var(--bg-main)] py-8 sm:py-10 md:py-12">
+        <div className="container mx-auto px-4 max-w-[1200px]">
+          <div className="bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 border border-blue-100 shadow-lg dark:bg-none dark:bg-[rgba(15,23,42,0.72)] dark:border-[var(--border-default)] dark:shadow-[0_20px_60px_rgba(0,0,0,0.25)] dark:backdrop-blur-xl rounded-2xl p-5 md:p-6 mb-6 md:mb-8">
             <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)_auto] gap-6 xl:gap-8 items-center">
               <div className="flex items-start gap-4">
-                <div className="p-4 bg-blue-100 rounded-2xl flex-shrink-0">
-                  <User className="h-8 w-8 text-[var(--accent)]" />
+                <div className="p-4 bg-blue-100 dark:bg-[rgba(59,130,246,0.16)] rounded-2xl flex-shrink-0">
+                  <User className="h-8 w-8 text-[var(--accent)] dark:text-[#93C5FD]" />
                 </div>
                 <div className="min-w-0 flex-1">
                   <h2 className="mb-2 text-xl sm:text-2xl md:text-3xl break-words">
@@ -277,17 +317,17 @@ export function MyPage() {
               </div>
 
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                <div className="rounded-2xl bg-white/70 backdrop-blur-sm border border-white/80 px-4 py-4 shadow-sm">
+                <div className="rounded-2xl bg-white/70 dark:bg-[rgba(15,23,42,0.58)] backdrop-blur-sm border border-white/80 dark:border-[var(--border-default)] px-4 py-4 shadow-sm">
                   <p className="text-xs font-medium text-[var(--muted-foreground)] mb-1">저장한 정책</p>
                   <p className="text-2xl font-semibold text-[var(--foreground)]">{statusCounts.all}</p>
                   <p className="text-xs text-[var(--muted-foreground)] mt-1">전체 저장 수</p>
                 </div>
-                <div className="rounded-2xl bg-white/70 backdrop-blur-sm border border-white/80 px-4 py-4 shadow-sm">
+                <div className="rounded-2xl bg-white/70 dark:bg-[rgba(15,23,42,0.58)] backdrop-blur-sm border border-white/80 dark:border-[var(--border-default)] px-4 py-4 shadow-sm">
                   <p className="text-xs font-medium text-[var(--muted-foreground)] mb-1">모집중</p>
                   <p className="text-2xl font-semibold text-emerald-600">{statusCounts.recruiting}</p>
                   <p className="text-xs text-[var(--muted-foreground)] mt-1">신청 가능한 정책</p>
                 </div>
-                <div className="rounded-2xl bg-white/70 backdrop-blur-sm border border-white/80 px-4 py-4 shadow-sm">
+                <div className="rounded-2xl bg-white/70 dark:bg-[rgba(15,23,42,0.58)] backdrop-blur-sm border border-white/80 dark:border-[var(--border-default)] px-4 py-4 shadow-sm">
                   <p className="text-xs font-medium text-[var(--muted-foreground)] mb-1">관심사</p>
                   <div className="flex flex-wrap gap-2 mt-3 min-h-[2.5rem]">
                     {(user?.interests ?? []).length > 0 ? (
@@ -301,7 +341,7 @@ export function MyPage() {
                 </div>
               </div>
 
-              <div className="rounded-2xl bg-white/75 backdrop-blur-sm border border-white/80 p-4 shadow-sm">
+              <div className="rounded-2xl bg-white/75 dark:bg-[rgba(15,23,42,0.62)] backdrop-blur-sm border border-white/80 dark:border-[var(--border-default)] p-4 shadow-sm">
                 <div className="flex items-center gap-4">
                   <div className="relative h-16 w-16 flex-shrink-0">
                     <svg className="h-16 w-16 -rotate-90" viewBox="0 0 64 64" aria-hidden="true">
@@ -339,11 +379,12 @@ export function MyPage() {
                     <p className="text-sm font-semibold text-[var(--foreground)]">프로필 완성도</p>
                   </div>
                 </div>
-                <div className="mt-4 pt-4 border-t border-blue-100/80">
+                <div className="mt-4 pt-4 border-t border-blue-100/80 dark:border-[var(--border-subtle)]">
                   <Button variant="secondary" className="gap-2 w-full justify-center bg-white hover:bg-blue-50" onClick={() => {
                     const stored = getStoredUserProfile();
                     setEditForm({
-                      age: stored ? String(stored.age) : '',
+                      displayName: stored?.displayName ?? '',
+                      age: stored?.age != null ? String(stored.age) : '',
                       regionCode: stored?.regionCode ?? '',
                       interests: stored?.interests ?? [],
                     });
@@ -357,7 +398,7 @@ export function MyPage() {
             </div>
           </div>
 
-          <div className="bg-white rounded-xl p-2 mb-6 flex flex-wrap gap-2">
+          <div className="bg-white dark:bg-[rgba(15,23,42,0.6)] dark:border dark:border-[var(--border-subtle)] rounded-2xl p-1.5 mb-6 flex flex-wrap gap-1 w-fit">
             <button
               onClick={() => { setStatusFilter('all'); setCurrentPage(1); }}
               className={`group inline-flex items-center px-4 py-2 rounded-lg text-sm transition-colors cursor-pointer ${
@@ -405,11 +446,11 @@ export function MyPage() {
           </div>
 
           {isLoading ? (
-            <div className="bg-white rounded-xl p-12 text-center text-[var(--muted-foreground)]">불러오는 중...</div>
+            <div className="bg-white dark:bg-[rgba(15,23,42,0.58)] dark:border dark:border-[var(--border-subtle)] rounded-2xl p-12 text-center text-[var(--muted-foreground)]">불러오는 중...</div>
           ) : hasError ? (
             <EmptyState type="error" onAction={handleRetry} actionLabel="다시 시도" />
           ) : filteredPolicies.length === 0 ? (
-            <div className="bg-white rounded-xl p-12 text-center">
+            <div className="bg-white dark:bg-transparent dark:border dark:border-dashed dark:border-[rgba(148,163,184,0.22)] rounded-2xl px-6 py-10 text-center max-w-md mx-auto">
               <p className="text-[var(--muted-foreground)] mb-4">저장된 정책이 없습니다</p>
               <Link to="/policies">
                 <Button variant="secondary">정책 찾으러 가기</Button>
@@ -423,7 +464,7 @@ export function MyPage() {
                   <PolicyCard {...policy} applicationStatus={!policy.startsAt && !policy.endsAt && !policy.isAlwaysOpen ? undefined : policy.applicationStatus} />
                   <div className="absolute top-4 right-4 z-10 transition-transform duration-300 ease-out group-hover:-translate-y-2">
                     <button
-                      className="p-2 bg-white/95 hover:bg-gray-50 border border-gray-300 hover:border-gray-400 rounded-xl shadow-sm transition-all duration-200 active:scale-95 backdrop-blur-sm cursor-pointer"
+                      className="p-2 bg-white/95 dark:bg-[rgba(15,23,42,0.85)] hover:bg-gray-50 dark:hover:bg-[rgba(30,41,59,0.9)] border border-gray-300 dark:border-[var(--border-default)] hover:border-gray-400 dark:hover:border-[var(--border-strong)] rounded-xl shadow-sm transition-all duration-200 active:scale-95 backdrop-blur-sm cursor-pointer"
                       onClick={(e) => {
                         e.preventDefault();
                         e.stopPropagation();
@@ -466,11 +507,11 @@ export function MyPage() {
 
       {deleteConfirmOpen && policyToDelete && (
         <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-2xl shadow-2xl p-6 w-full max-w-md">
+          <div className="bg-white dark:bg-[rgba(15,23,42,0.95)] dark:backdrop-blur-xl dark:border dark:border-[var(--border-default)] rounded-2xl shadow-2xl p-6 w-full max-w-md">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-lg font-semibold">정책 삭제 확인</h3>
               <button
-                className="p-1 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
+                className="p-1 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-[rgba(30,41,59,0.6)] dark:hover:text-white transition-colors cursor-pointer"
                 onClick={() => setDeleteConfirmOpen(false)}
               >
                 <X className="h-5 w-5" />
@@ -498,23 +539,37 @@ export function MyPage() {
 
       {editProfileOpen && (
         <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-2xl shadow-2xl p-6 w-full max-w-md">
+          <div className="bg-white dark:bg-[rgba(15,23,42,0.95)] dark:backdrop-blur-xl dark:border dark:border-[var(--border-default)] rounded-2xl shadow-2xl p-6 w-full max-w-md">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-lg font-semibold">프로필 수정</h3>
               <button
-                className="p-1 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
+                className="p-1 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-[rgba(30,41,59,0.6)] dark:hover:text-white transition-colors cursor-pointer"
                 onClick={() => setEditProfileOpen(false)}
               >
                 <X className="h-5 w-5" />
               </button>
             </div>
-            <form className="space-y-4">
+            <form
+              className="space-y-4"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void handleSaveProfile();
+              }}
+            >
+              <div>
+                <label className="block text-sm font-medium mb-2">표시 이름</label>
+                <Input
+                  value={editForm.displayName}
+                  onChange={(e) => setEditForm((current) => ({ ...current, displayName: e.target.value }))}
+                  placeholder="예: 홍길동"
+                />
+              </div>
               <div>
                 <label className="block text-sm font-medium mb-2">나이</label>
                 <Input
                   type="number"
-                  min={1}
-                  max={140}
+                  min={14}
+                  max={120}
                   value={editForm.age}
                   onChange={(e) => setEditForm((current) => ({ ...current, age: e.target.value }))}
                 />
@@ -529,6 +584,7 @@ export function MyPage() {
               </div>
               <div>
                 <label className="block text-sm font-medium mb-2">관심사</label>
+                <p className="mb-2 text-xs text-[var(--muted-foreground)]">최대 {MAX_INTERESTS}개까지 선택할 수 있어요.</p>
                 <div className="flex flex-col gap-2">
                   {INTEREST_OPTIONS.map((opt) => {
                     const isSelected = editForm.interests.includes(opt.value);
@@ -536,18 +592,23 @@ export function MyPage() {
                       <button
                         key={opt.value}
                         type="button"
-                        onClick={() =>
+                        onClick={() => {
                           setEditForm((current) => ({
                             ...current,
                             interests: isSelected
                               ? current.interests.filter((i) => i !== opt.value)
-                              : [...current.interests, opt.value],
-                          }))
-                        }
+                              : current.interests.length >= MAX_INTERESTS
+                                ? current.interests
+                                : [...current.interests, opt.value],
+                          }));
+                          if (!isSelected && editForm.interests.length >= MAX_INTERESTS) {
+                            toast.info(`관심사는 최대 ${MAX_INTERESTS}개까지 선택할 수 있어요.`);
+                          }
+                        }}
                         className={`flex items-center gap-3 px-4 py-3 rounded-xl border text-sm font-medium transition-colors text-left cursor-pointer ${
                           isSelected
-                            ? 'border-[var(--accent)] bg-blue-50 text-[var(--accent)]'
-                            : 'border-[var(--border)] bg-white text-[var(--foreground)] hover:bg-[var(--muted)]'
+                            ? 'border-[var(--accent)] bg-blue-50 text-[var(--accent)] dark:bg-[rgba(59,130,246,0.12)] dark:text-[#93C5FD]'
+                            : 'border-[var(--border)] bg-white text-[var(--foreground)] hover:bg-[var(--muted)] dark:bg-[rgba(30,41,59,0.4)] dark:hover:bg-[rgba(30,41,59,0.7)]'
                         }`}
                       >
                         <div
@@ -561,17 +622,18 @@ export function MyPage() {
                             </svg>
                           )}
                         </div>
-                        {opt.label}
+                        <span className="flex-1">{opt.label}</span>
+                        <span className="text-xs text-[var(--muted-foreground)]">선택 가능</span>
                       </button>
                     );
                   })}
                 </div>
               </div>
               <div className="flex justify-end gap-2 pt-4">
-                <Button variant="secondary" className="px-4 py-2" onClick={() => setEditProfileOpen(false)}>
+                <Button type="button" variant="secondary" className="px-4 py-2" onClick={() => setEditProfileOpen(false)}>
                   취소
                 </Button>
-                <Button variant="primary" className="px-4 py-2" onClick={handleSaveProfile}>
+                <Button type="submit" variant="primary" className="px-4 py-2" loading={editProfileLoading}>
                   저장
                 </Button>
               </div>

--- a/frontend/src/app/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/app/pages/OAuthCallbackPage.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import {
   buildOAuthUserProfile,
   setAccessToken,
+  setAuthMethod,
   setStoredUserProfile,
 } from '../api/client';
 
@@ -30,6 +31,7 @@ export function OAuthCallbackPage() {
     }
 
     setAccessToken(token);
+    setAuthMethod('oauth');
     setStoredUserProfile(profile);
 
     if (!profileCompleted) {

--- a/frontend/src/app/pages/OnboardingPage.tsx
+++ b/frontend/src/app/pages/OnboardingPage.tsx
@@ -11,10 +11,13 @@ import { REGION_OPTIONS } from '../lib/regions';
 import type { Gender, InterestCategory, RegionCode } from '../types';
 
 const CURRENT_YEAR = 2026;
+const MAX_INTERESTS = 2;
 
-const interestOptions: Array<{ value: InterestCategory; label: string; enabled: boolean }> = [
-  { value: 'youth_policy', label: '청년정책', enabled: true },
-  { value: 'childcare_policy', label: '육아정책 (추후 제공)', enabled: false },
+const interestOptions: Array<{ id: string; value?: InterestCategory; label: string }> = [
+  { id: 'youth_policy', value: 'youth_policy', label: '청년정책' },
+  { id: 'childcare_policy', value: 'childcare_policy', label: '육아정책' },
+  { id: 'senior_policy', value: 'senior_policy', label: '노인정책' },
+  { id: 'disability_policy', value: 'disability_policy', label: '장애인정책' },
 ];
 
 export function OnboardingPage() {
@@ -24,7 +27,7 @@ export function OnboardingPage() {
     birthYear: '',
     gender: 'unspecified' as Gender,
     regionCode: 'seoul' as RegionCode,
-    interests: ['youth_policy'] as InterestCategory[],
+    interests: ['youth_policy'],
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
 
@@ -58,6 +61,8 @@ export function OnboardingPage() {
 
     if (formData.interests.length === 0) {
       nextErrors.interests = '관심 분야를 1개 이상 선택해주세요';
+    } else if (formData.interests.length > MAX_INTERESTS) {
+      nextErrors.interests = `관심 분야는 최대 ${MAX_INTERESTS}개까지 선택할 수 있습니다`;
     }
 
     setErrors(nextErrors);
@@ -78,7 +83,9 @@ export function OnboardingPage() {
         age: Math.max(0, CURRENT_YEAR - birthYear),
         gender: formData.gender,
         regionCode: formData.regionCode,
-        interests: formData.interests,
+        interests: formData.interests
+          .map((interest) => interestOptions.find((option) => option.id === interest)?.value)
+          .filter(Boolean) as InterestCategory[],
       });
 
       toast.success('프로필이 완성되었습니다.');
@@ -124,11 +131,10 @@ export function OnboardingPage() {
 
           <div>
             <label className="block mb-2">성별</label>
-            <div className="grid grid-cols-4 gap-2">
+            <div className="grid grid-cols-3 gap-2">
               {[
                 ['male', '남성'],
                 ['female', '여성'],
-                ['other', '기타'],
                 ['unspecified', '선택 안 함'],
               ].map(([value, label]) => (
                 <Chip
@@ -161,32 +167,41 @@ export function OnboardingPage() {
 
           <div>
             <label className="block mb-3">관심 분야</label>
+            <p className="mb-3 text-xs text-[var(--muted-foreground)]">최대 {MAX_INTERESTS}개까지 선택할 수 있어요.</p>
             <div className="space-y-2">
               {interestOptions.map((interest) => {
-                const selected = formData.interests.includes(interest.value);
+                const selected = formData.interests.includes(interest.id);
                 return (
                   <button
-                    key={interest.value}
+                    key={interest.id}
                     type="button"
-                    disabled={!interest.enabled}
                     onClick={() => {
-                      if (!interest.enabled) return;
                       setFormData({
                         ...formData,
                         interests: selected
-                          ? formData.interests.filter((item) => item !== interest.value)
-                          : [...formData.interests, interest.value],
+                          ? formData.interests.filter((item) => item !== interest.id)
+                          : formData.interests.length >= MAX_INTERESTS
+                            ? formData.interests
+                            : [...formData.interests, interest.id],
                       });
+                      if (!selected && formData.interests.length >= MAX_INTERESTS) {
+                        setErrors((current) => ({
+                          ...current,
+                          interests: `관심 분야는 최대 ${MAX_INTERESTS}개까지 선택할 수 있습니다`,
+                        }));
+                      } else {
+                        setErrors((current) => ({ ...current, interests: '' }));
+                      }
                     }}
                     className={`w-full rounded-xl border p-4 text-left transition-colors ${
                       selected
                         ? 'border-[var(--accent)] bg-blue-50'
                         : 'border-[var(--border)] hover:bg-[var(--muted)]'
-                    } ${!interest.enabled ? 'cursor-not-allowed opacity-50' : ''}`}
+                    }`}
                   >
                     <div className="flex items-center justify-between">
                       <span className="text-sm font-medium">{interest.label}</span>
-                      {!interest.enabled && <span className="text-xs text-[var(--muted-foreground)]">추후 제공</span>}
+                      <span className="text-xs text-[var(--muted-foreground)]">선택 가능</span>
                     </div>
                   </button>
                 );

--- a/frontend/src/app/pages/PersonalizedPoliciesPage.tsx
+++ b/frontend/src/app/pages/PersonalizedPoliciesPage.tsx
@@ -2,8 +2,9 @@ import { useEffect, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 import { ArrowRight, MapPin, User as UserIcon, LogIn, Gift } from 'lucide-react';
 import { toast } from 'sonner';
+import { updateProfile } from '../api/auth';
 import { getPoliciesRecommended } from '../api/policies';
-import { ApiClientError, getAccessToken, getEmailVerificationPath, getStoredUserProfile, setStoredUserProfile } from '../api/client';
+import { ApiClientError, getAccessToken, getEmailVerificationPath, getStoredUserProfile } from '../api/client';
 import { MainLayout } from '../components/templates/MainLayout';
 import { PolicyList } from '../components/organisms/PolicyList';
 import { PolicyCardSkeleton } from '../components/molecules/PolicyCardSkeleton';
@@ -57,7 +58,7 @@ export function PersonalizedPoliciesPage() {
 
       try {
         const response = await getPoliciesRecommended({
-          interest: currentUser.interests.length > 0 ? currentUser.interests[0] : undefined,
+          interests: currentUser.interests.length > 0 ? currentUser.interests : undefined,
           sortBy: 'relevance',
           order: 'desc',
           onlyAvailable: true,
@@ -84,9 +85,9 @@ export function PersonalizedPoliciesPage() {
   if (!isLoading && !isAuthenticated) {
     return (
       <MainLayout>
-        <div className="min-h-[calc(100vh-4rem)] bg-gradient-to-b from-blue-50/50 to-white flex items-center justify-center px-4 py-12">
+        <div className="min-h-[calc(100vh-4rem)] bg-gradient-to-b from-blue-50/50 to-white dark:bg-none dark:bg-[var(--bg-main)] flex items-center justify-center px-4 py-12">
           <div className="max-w-lg w-full">
-            <div className="bg-white rounded-2xl shadow-xl shadow-blue-500/10 p-8 md:p-12 text-center border border-[var(--border)]">
+            <div className="bg-white dark:bg-[rgba(15,23,42,0.72)] dark:backdrop-blur-xl rounded-2xl shadow-xl shadow-blue-500/10 dark:shadow-[0_20px_60px_rgba(0,0,0,0.35)] p-8 md:p-12 text-center border border-[var(--border)] dark:border-[var(--border-default)]">
               <div className="relative inline-flex items-center justify-center mb-8">
                 <div className="w-20 h-20 bg-gradient-to-br from-blue-100 to-purple-100 rounded-full flex items-center justify-center">
                   <Gift className="h-10 w-10 text-[var(--accent)]" />
@@ -103,10 +104,10 @@ export function PersonalizedPoliciesPage() {
                 맞춤형 정책만 모아서 제공해드립니다
               </p>
 
-              <div className="bg-gradient-to-br from-blue-50 to-purple-50 rounded-xl p-6 mb-8 space-y-4">
+              <div className="bg-gradient-to-br from-blue-50 to-purple-50 dark:bg-none dark:bg-[rgba(15,23,42,0.5)] dark:border dark:border-[var(--border-subtle)] rounded-xl p-6 mb-8 space-y-4">
                 <div className="flex items-start gap-3 text-left">
-                  <div className="p-2.5 bg-white rounded-xl shadow-sm">
-                    <UserIcon className="h-5 w-5 text-[var(--accent)]" />
+                  <div className="p-2.5 bg-white dark:bg-[rgba(15,23,42,0.7)] dark:border dark:border-[var(--border-subtle)] rounded-xl shadow-sm">
+                    <UserIcon className="h-5 w-5 text-[var(--accent)] dark:text-[#93C5FD]" />
                   </div>
                   <div>
                     <p className="font-medium mb-1 text-sm">개인화된 정책 추천</p>
@@ -116,8 +117,8 @@ export function PersonalizedPoliciesPage() {
                   </div>
                 </div>
                 <div className="flex items-start gap-3 text-left">
-                  <div className="p-2.5 bg-white rounded-xl shadow-sm">
-                    <MapPin className="h-5 w-5 text-[var(--accent)]" />
+                  <div className="p-2.5 bg-white dark:bg-[rgba(15,23,42,0.7)] dark:border dark:border-[var(--border-subtle)] rounded-xl shadow-sm">
+                    <MapPin className="h-5 w-5 text-[var(--accent)] dark:text-[#93C5FD]" />
                   </div>
                   <div>
                     <p className="font-medium mb-1 text-sm">지역별 맞춤 정책</p>
@@ -160,13 +161,21 @@ export function PersonalizedPoliciesPage() {
 
   return (
     <MainLayout>
-      <div className="bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 border-b border-blue-100 py-8 sm:py-10 md:py-12">
-        <div className="container mx-auto px-4">
+      <div className="bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 border-b border-blue-100 dark:bg-none dark:bg-[var(--bg-main)] dark:border-[var(--border-subtle)] py-10 sm:py-12 md:py-14 relative">
+        <div
+          aria-hidden="true"
+          className="hidden dark:block absolute inset-0 pointer-events-none"
+          style={{
+            backgroundImage:
+              'radial-gradient(circle at 18% 30%, rgba(59,130,246,0.10), transparent 38%), radial-gradient(circle at 82% 60%, rgba(139,92,246,0.10), transparent 42%)',
+          }}
+        ></div>
+        <div className="container mx-auto px-4 max-w-[1200px] relative">
           <div className="grid grid-cols-1 lg:grid-cols-[1fr_auto] gap-6 lg:gap-8 items-start">
             <div>
               <div className="flex items-center gap-2 mb-3">
-                <div className="p-2 bg-white rounded-xl shadow-sm">
-                  <Gift className="h-5 w-5 text-[var(--accent)]" />
+                <div className="p-2 bg-white dark:bg-[rgba(15,23,42,0.7)] dark:border dark:border-[var(--border-subtle)] rounded-xl shadow-sm">
+                  <Gift className="h-5 w-5 text-[var(--accent)] dark:text-[#93C5FD]" />
                 </div>
                 <span className="text-sm font-medium text-[var(--muted-foreground)]">맞춤정책</span>
               </div>
@@ -203,25 +212,38 @@ export function PersonalizedPoliciesPage() {
                     return;
                   }
 
-                  const nextUser = { ...storedUser };
-                  if (field === 'age') {
-                    nextUser.age = Number(value) || storedUser.age;
-                  } else if (field === 'region') {
-                    const code = REGION_CODE_BY_LABEL[value];
-                    if (code) {
-                      nextUser.regionCode = code as typeof storedUser.regionCode;
-                    }
-                  } else if (field === 'interests') {
+                  void (async () => {
                     try {
-                      nextUser.interests = JSON.parse(value) as typeof storedUser.interests;
-                    } catch {
-                      return;
-                    }
-                  }
+                      if (field === 'age') {
+                        const age = Number(value);
+                        if (!Number.isInteger(age) || age < 14 || age > 120) {
+                          toast.error('나이는 14세 이상 120세 이하로 입력해주세요.');
+                          return;
+                        }
+                        await updateProfile({ age });
+                      } else if (field === 'region') {
+                        const code = REGION_CODE_BY_LABEL[value];
+                        if (!code) {
+                          toast.error('지역 정보를 확인할 수 없습니다.');
+                          return;
+                        }
+                        await updateProfile({ regionCode: code as NonNullable<typeof storedUser.regionCode> });
+                      } else if (field === 'interests') {
+                        const interests = JSON.parse(value) as typeof storedUser.interests;
+                        if (!Array.isArray(interests) || interests.length === 0) {
+                          toast.error('관심사를 1개 이상 선택해주세요.');
+                          return;
+                        }
+                        await updateProfile({ interests });
+                      }
 
-                  setStoredUserProfile(nextUser);
-                  toast.success('프로필이 업데이트되었습니다.');
-                  setReloadKey((current) => current + 1);
+                      toast.success('프로필이 업데이트되었습니다.');
+                      setReloadKey((current) => current + 1);
+                    } catch (error) {
+                      const message = error instanceof ApiClientError ? error.message : '프로필 업데이트에 실패했습니다.';
+                      toast.error(message);
+                    }
+                  })();
                 }}
               />
             </div>
@@ -230,15 +252,15 @@ export function PersonalizedPoliciesPage() {
       </div>
 
       <div className="container mx-auto px-4 py-8">
-        <div className="bg-blue-50/50 border border-blue-200/50 rounded-xl p-4 mb-8 flex items-start gap-3">
-          <div className="p-2 bg-blue-100 rounded-lg">
-            <Gift className="h-4 w-4 text-blue-600 flex-shrink-0" />
+        <div className="bg-blue-50/50 border border-blue-200/50 dark:bg-[rgba(59,130,246,0.08)] dark:border-[rgba(96,165,250,0.20)] rounded-xl p-3.5 mb-8 flex items-start gap-3">
+          <div className="p-2 bg-blue-100 dark:bg-[rgba(96,165,250,0.16)] rounded-lg">
+            <Gift className="h-4 w-4 text-blue-600 dark:text-[#93C5FD] flex-shrink-0" />
           </div>
           <div className="text-sm">
-            <p className="text-blue-900 font-medium mb-1">이 정책들을 확인해보세요!</p>
-            <p className="text-blue-700">
+            <p className="text-blue-900 dark:text-[var(--text-primary)] font-medium mb-1">이 정책들을 확인해보세요!</p>
+            <p className="text-blue-700 dark:text-[var(--text-secondary)]">
               회원님의 연령과 지역 조건에 맞는 정책만 선별했습니다.
-              <Link to="/me" className="underline ml-1 hover:text-blue-900 font-medium">
+              <Link to="/me" className="underline ml-1 hover:text-blue-900 dark:hover:text-white font-medium">
                 프로필을 수정
               </Link>
               하면 더 정확한 추천을 받을 수 있습니다.
@@ -259,7 +281,7 @@ export function PersonalizedPoliciesPage() {
         )}
 
         {!isLoading && !hasError && personalizedPolicies.length === 0 && (
-          <div className="bg-white rounded-xl p-12 text-center">
+          <div className="bg-white dark:bg-transparent dark:border dark:border-dashed dark:border-[rgba(148,163,184,0.22)] rounded-2xl px-6 py-10 text-center max-w-lg mx-auto">
             <Gift className="h-12 w-12 text-[var(--muted-foreground)] mx-auto mb-4" />
             <h3 className="mb-2">현재 조건에 맞는 정책이 없습니다</h3>
             <p className="text-[var(--muted-foreground)] mb-6">

--- a/frontend/src/app/pages/PoliciesPage.tsx
+++ b/frontend/src/app/pages/PoliciesPage.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigationType, useSearchParams } from 'react-router';
 import { Filter } from 'lucide-react';
 import { toast } from 'sonner';
 import { motion, AnimatePresence } from 'motion/react';
-import { getPolicies } from '../api/policies';
+import { getPolicies, getPoliciesRecommended } from '../api/policies';
 import { ApiClientError, getAccessToken, getStoredUserProfile } from '../api/client';
 import { MainLayout } from '../components/templates/MainLayout';
 import { SearchBar } from '../components/molecules/SearchBar';
@@ -14,7 +14,7 @@ import { ExpandableFilters, ExpandableFiltersState } from '../components/organis
 import { EmptyState } from '../components/molecules/EmptyState';
 import { PolicyCardSkeleton } from '../components/molecules/PolicyCardSkeleton';
 import { Button } from '../components/atoms/Button';
-import type { PolicyListItem, RegionCode } from '../types';
+import type { InterestCategory, PolicyListItem, RegionCode } from '../types';
 import { REGION_LABELS } from '../lib/regions';
 
 const PAGE_SIZE = 12;
@@ -39,8 +39,16 @@ const TEMP_VISIBILITY_TEST_LABELS: Record<string, string> = Object.fromEntries(
 const CATEGORY_LABELS: Record<string, string> = {
   youth_policy: '청년정책',
   childcare_policy: '육아정책',
+  senior_policy: '노인정책',
+  disability_policy: '장애인정책',
   ...TEMP_VISIBILITY_TEST_LABELS,
 };
+const SUPPORTED_CATEGORY_FILTERS = [
+  'youth_policy',
+  'childcare_policy',
+  'senior_policy',
+  'disability_policy',
+] as const;
 const FILTER_REGION_LABELS: Record<string, string> = { ...REGION_LABELS, ...TEMP_VISIBILITY_TEST_LABELS };
 const AGE_LABELS: Record<string, string> = {
   '19-24': '19-24세', '25-29': '25-29세', '30-34': '30-34세',
@@ -52,7 +60,6 @@ const EMPLOYMENT_LABELS: Record<string, string> = {
 };
 type StatusFilter = 'recruiting' | 'always' | 'period_raw' | 'unknown';
 
-const DAY_MS = 24 * 60 * 60 * 1000;
 const SORT_OPTIONS = new Set<SortOption>(['latest', 'deadline', 'recommended']);
 
 function getSortOption(value: string | null): SortOption {
@@ -98,54 +105,9 @@ function sortPoliciesByDeadline(policies: PolicyListItem[], now = Date.now()) {
   });
 }
 
-function stableExplorationOffset(id: string) {
-  let hash = 0;
-  for (let index = 0; index < id.length; index += 1) {
-    hash = (hash * 31 + id.charCodeAt(index)) % 997;
-  }
-  return (hash % 17) / 10;
-}
-
-function getRecommendedScore(policy: PolicyListItem) {
-  const user = getStoredUserProfile();
-  if (!user) return 0;
-
-  let score = 0;
-  if (policy.categories.some((category) => user.interests.includes(category))) score += 42;
-  if (user.regionCode && policy.regionCodes.includes(user.regionCode)) score += 26;
-  if (
-    user.age !== null &&
-    (policy.minAge === null || user.age >= policy.minAge) &&
-    (policy.maxAge === null || user.age <= policy.maxAge)
-  ) {
-    score += 22;
-  }
-
-  const deadlineRank = getDeadlineRank(policy);
-  if (deadlineRank === 0) score += 8;
-  else if (deadlineRank === 1) score += 5;
-  else if (deadlineRank === 2) score += 2;
-  else if (deadlineRank === 4) score -= 20;
-
-  const deadline = getTime(policy.endsAt);
-  if (deadline && deadline > Date.now()) {
-    score += Math.max(0, 4 - Math.floor((deadline - Date.now()) / (30 * DAY_MS)));
-  }
-
-  return score + stableExplorationOffset(policy.id);
-}
-
-function sortPoliciesByRecommended(policies: PolicyListItem[]) {
-  return [...policies].sort((a, b) => {
-    const scoreDiff = getRecommendedScore(b) - getRecommendedScore(a);
-    if (scoreDiff !== 0) return scoreDiff;
-    return a.title.localeCompare(b.title, 'ko');
-  });
-}
-
 function sortPoliciesForView(policies: PolicyListItem[], sortBy: SortOption) {
   if (sortBy === 'deadline') return sortPoliciesByDeadline(policies);
-  if (sortBy === 'recommended') return sortPoliciesByRecommended(policies);
+  if (sortBy === 'recommended') return policies;
   return sortPoliciesByLatest(policies);
 }
 
@@ -262,14 +224,23 @@ export function PoliciesPage() {
       try {
         const rawRegion = committedFilters.regions.find((r) => r !== 'all');
         const selectedRegion = rawRegion ? (rawRegion as RegionCode) : undefined;
-        const selectedInterest = committedFilters.categories[0] as 'youth_policy' | 'childcare_policy' | undefined;
-        const apiSortBy = sortBy === 'recommended' ? 'latest' : sortBy;
-        const response = await getPolicies({
+        const selectedInterests = committedFilters.categories.filter(
+          (category): category is InterestCategory =>
+            SUPPORTED_CATEGORY_FILTERS.includes(category as typeof SUPPORTED_CATEGORY_FILTERS[number]),
+        );
+        const shouldUseRecommended = isAuthenticated && sortBy === 'recommended';
+        const apiSortBy = shouldUseRecommended
+          ? 'relevance'
+          : sortBy === 'recommended'
+            ? 'latest'
+            : sortBy;
+        const response = await (shouldUseRecommended ? getPoliciesRecommended : getPolicies)({
           search: searchQuery || undefined,
           sortBy: apiSortBy,
           order: 'desc',
           regionCode: selectedRegion,
-          interest: selectedInterest,
+          interests: selectedInterests.length > 0 ? selectedInterests : undefined,
+          onlyAvailable: shouldUseRecommended ? true : undefined,
         });
         setPolicies(response.items);
       } catch (error) {
@@ -281,7 +252,7 @@ export function PoliciesPage() {
       }
     };
     loadPolicies();
-  }, [searchQuery, sortBy, committedFilters, reloadKey]);
+  }, [searchQuery, sortBy, committedFilters, isAuthenticated, reloadKey]);
 
   useEffect(() => {
     if (!isAuthenticated && sortParam === 'recommended') {
@@ -366,13 +337,13 @@ export function PoliciesPage() {
       if (statusFilter === 'unknown') return !p.isAlwaysOpen && !p.endsAt && !p.periodRaw;
       return true;
       })
-      .filter(p => !typeFilter || (p as any).policyType === typeFilter),
+      .filter(p => !typeFilter || p.policyType === typeFilter),
     sortBy,
   );
 
   return (
     <MainLayout>
-      <div className="bg-white/80 backdrop-blur-sm border-b border-[var(--border)] md:sticky md:top-16 md:z-40 shadow-sm">
+      <div data-page="policies" className="bg-white/80 dark:bg-[rgba(8,13,23,0.78)] backdrop-blur-xl border-b border-[var(--border)] dark:border-[var(--border-subtle)] md:sticky md:top-[68px] md:z-40 shadow-sm dark:shadow-none">
         <div className="container mx-auto px-3 sm:px-4 py-3 sm:py-4 md:py-6 space-y-3 md:space-y-4">
           {/* Title + Stats */}
           {!isLoading && !hasError && policies.length > 0 && (
@@ -488,7 +459,7 @@ export function PoliciesPage() {
       </div>
 
       {/* Results */}
-      <div className="container mx-auto px-4 py-8">
+      <div data-page="policies" className="container mx-auto px-4 py-8">
         {!isLoading && !hasError && policies.length > 0 && (
           <div className="mb-6">
             <p className="text-[var(--muted-foreground)]">

--- a/frontend/src/app/pages/PolicyDetailPage.tsx
+++ b/frontend/src/app/pages/PolicyDetailPage.tsx
@@ -315,7 +315,7 @@ export function PolicyDetailPage() {
 
         // 연관 정책 로드
         if (response.categories?.length) {
-          const category = response.categories[0] as 'youth_policy' | 'childcare_policy';
+          const category = response.categories[0];
           const related = await getPolicies({ interest: category });
           const filtered = related.items.filter((p) => p.id !== id);
           const shuffled = [...filtered].sort(() => Math.random() - 0.5);
@@ -416,15 +416,14 @@ export function PolicyDetailPage() {
   const rawCriteria = policy?.eligibilityInfo?.selectionCriteria?.trim();
   // 마크다운 기호, 공백, 불릿 제거 후 실제 텍스트가 있을 때만 표시
   const selectionCriteria = rawCriteria && rawCriteria.replace(/[\s\-*•·]/g, '').length > 0 ? rawCriteria : null;
+  const warnBox = policy?.eligibilityInfo?.warnBox?.trim() || null;
 
   const visibleRequirements = (policy?.requirements ?? [])
     .filter((req, i, arr) => arr.findIndex((r) => r.key === req.key) === i)
     .filter((req) => req.key !== 'selection_criteria' && req.label !== '선정기준');
   const hasRequirements = visibleRequirements.length > 0;
   const completedRequirementCount = visibleRequirements.filter((req) => eligibilityAnswers[req.key]).length;
-  // [임시] UI 확인용 — 아동복지시설 보호아동지원 정책을 info처럼 동작하게 처리 (확인 후 아래 한 줄 제거)
-  const TEMP_INFO_POLICY_ID = 'de99e7da-360c-4071-9899-1d6ded895d60';
-  const isInfoPolicy = policy?.policyType === 'info' || policy?.id === TEMP_INFO_POLICY_ID;
+  const isInfoPolicy = policy?.policyType === 'info';
   const canCheckEligibility = hasRequirements && !isInfoPolicy;
 
   const sections = [
@@ -479,7 +478,7 @@ export function PolicyDetailPage() {
   const responseSourceType = isSourceType(
     eligibilityResult?.policy?.sourceType,
   )
-    ? eligibilityResult.policy.sourceType
+    ? eligibilityResult.policy?.sourceType
     : isSourceType(policy.sourceType)
       ? policy.sourceType
       : null;
@@ -625,6 +624,22 @@ export function PolicyDetailPage() {
                 <ReactMarkdown remarkPlugins={[remarkBreaks, remarkGfmNoSingleTilde]}>{getTargetText(policy)}</ReactMarkdown>
               </div>
             </motion.section>
+
+            {warnBox && (
+              <motion.section
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.42 }}
+                className="rounded-2xl border border-amber-200 bg-amber-50 p-5 shadow-sm"
+              >
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+                  <div className="prose prose-sm max-w-none text-amber-950">
+                    <ReactMarkdown remarkPlugins={[remarkBreaks, remarkGfmNoSingleTilde]}>{warnBox}</ReactMarkdown>
+                  </div>
+                </div>
+              </motion.section>
+            )}
 
             {/* Selection Criteria */}
             {selectionCriteria && (
@@ -820,19 +835,19 @@ export function PolicyDetailPage() {
                       );
                     })}
                     <div className="rounded-2xl border border-emerald-200 bg-white p-3 shadow-sm">
-                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                        <div className="min-w-0 flex-1">
                           <p className="text-sm font-semibold text-emerald-900">
                             {visibleRequirements.length}개 중 {completedRequirementCount}개 입력됨
                           </p>
-                          <div className="mt-2 h-1.5 w-full rounded-full bg-emerald-100 sm:w-44">
+                          <div className="mt-2 h-1.5 w-full rounded-full bg-emerald-100">
                             <div
                               className="h-full rounded-full bg-emerald-500 transition-all"
                               style={{ width: `${visibleRequirements.length ? (completedRequirementCount / visibleRequirements.length) * 100 : 0}%` }}
                             />
                           </div>
                         </div>
-                        <div className="flex flex-col gap-2 sm:flex-row">
+                        <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
                           <Button
                             type="submit"
                             className="h-10 w-full min-w-32 bg-emerald-600 px-6 text-sm hover:bg-emerald-700 sm:w-auto"
@@ -865,7 +880,7 @@ export function PolicyDetailPage() {
                         <p className="text-sm font-semibold text-emerald-900 mb-1">신청 가능합니다 🎉</p>
                         <p className="text-xs text-emerald-700 mb-3">{eligibilityResult.explanation}</p>
                         <Button className="bg-emerald-600 hover:bg-emerald-700 text-xs h-8" size="sm"
-                          onClick={() => window.open(getSourceUrl(eligibilityResult.policy.applicationUrl ?? policy.applicationUrl ?? policy.sourceUrl, policy.title), '_blank', 'noopener,noreferrer')}
+                          onClick={() => window.open(getSourceUrl(eligibilityResult.policy?.applicationUrl ?? policy.applicationUrl ?? policy.sourceUrl, policy.title), '_blank', 'noopener,noreferrer')}
                         >
                           <ExternalLink className="h-3.5 w-3.5 mr-1.5" />신청하러 가기
                         </Button>
@@ -1036,9 +1051,15 @@ export function PolicyDetailPage() {
               >
                 <Button
                   className="w-full gap-2 bg-blue-600 hover:bg-blue-700 shadow-sm"
-                  onClick={() => window.open(getSourceUrl(policy.applicationUrl ?? policy.sourceUrl, policy.title), '_blank', 'noopener,noreferrer')}
+                  onClick={() => window.open(
+                    isInfoPolicy
+                      ? getSourceUrl(policy.sourceUrl, policy.title)
+                      : getSourceUrl(policy.applicationUrl ?? policy.sourceUrl, policy.title),
+                    '_blank',
+                    'noopener,noreferrer',
+                  )}
                 >
-                  <ExternalLink className="h-4 w-4" />지금 신청하기
+                  <ExternalLink className="h-4 w-4" />{isInfoPolicy ? '원문 보기' : '지금 신청하기'}
                 </Button>
                 <Button variant="ghost" className="w-full gap-2" onClick={handleBookmark} aria-pressed={bookmarked}>
                   <Bookmark className={bookmarked ? 'fill-current' : ''} />

--- a/frontend/src/app/pages/ProfilePage.tsx
+++ b/frontend/src/app/pages/ProfilePage.tsx
@@ -1,20 +1,47 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 import { LockKeyhole, ShieldAlert, User } from 'lucide-react';
+import { toast } from 'sonner';
+import { changePassword, deleteAccount } from '../api/auth';
 import { MainLayout } from '../components/templates/MainLayout';
 import { Button } from '../components/atoms/Button';
 import { Input } from '../components/atoms/Input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
-import { getEmailVerificationPath, getStoredUserProfile } from '../api/client';
+import {
+  ApiClientError,
+  clearAuthMethod,
+  clearAccessToken,
+  clearStoredUserProfile,
+  getAuthMethod,
+  getEmailVerificationPath,
+  getStoredUserProfile,
+} from '../api/client';
 
 export function ProfilePage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const user = getStoredUserProfile();
-  const userName = user ? user.email.split('@')[0] : '사용자';
-  const activeTab = searchParams.get('tab') === 'withdraw' ? 'withdraw' : 'password';
+  const isOAuthUser = getAuthMethod() === 'oauth';
+  const userName = user ? user.displayName || user.email.split('@')[0] : '사용자';
+  const activeTab = isOAuthUser || searchParams.get('tab') === 'withdraw' ? 'withdraw' : 'password';
+  const [passwordForm, setPasswordForm] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+  });
+  const [deleteForm, setDeleteForm] = useState({
+    confirmText: '',
+    password: '',
+  });
+  const [passwordLoading, setPasswordLoading] = useState(false);
+  const [deleteLoading, setDeleteLoading] = useState(false);
 
   useEffect(() => {
+    if (!user) {
+      navigate('/login', { replace: true });
+      return;
+    }
+
     if (user && !user.emailVerified) {
       navigate(getEmailVerificationPath(user.email), { replace: true });
       return;
@@ -25,13 +52,73 @@ export function ProfilePage() {
     }
   }, [navigate, user]);
 
+  const handleChangePassword = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!passwordForm.currentPassword || !passwordForm.newPassword) {
+      toast.error('현재 비밀번호와 새 비밀번호를 입력해주세요.');
+      return;
+    }
+    if (passwordForm.newPassword.length < 8) {
+      toast.error('새 비밀번호는 8자 이상이어야 합니다.');
+      return;
+    }
+    if (passwordForm.newPassword !== passwordForm.confirmPassword) {
+      toast.error('새 비밀번호가 일치하지 않습니다.');
+      return;
+    }
+
+    setPasswordLoading(true);
+    try {
+      await changePassword({
+        currentPassword: passwordForm.currentPassword,
+        newPassword: passwordForm.newPassword,
+      });
+      setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+      toast.success('비밀번호가 변경되었습니다.');
+    } catch (error) {
+      const message = error instanceof ApiClientError ? error.message : '비밀번호 변경에 실패했습니다.';
+      toast.error(message);
+    } finally {
+      setPasswordLoading(false);
+    }
+  };
+
+  const handleDeleteAccount = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (deleteForm.confirmText.trim() !== '탈퇴') {
+      toast.error('확인 문구를 정확히 입력해주세요.');
+      return;
+    }
+    if (!isOAuthUser && !deleteForm.password) {
+      toast.error('비밀번호를 입력해주세요.');
+      return;
+    }
+
+    setDeleteLoading(true);
+    try {
+      await deleteAccount(isOAuthUser ? {} : { password: deleteForm.password });
+      clearAccessToken();
+      clearAuthMethod();
+      clearStoredUserProfile();
+      toast.success('회원탈퇴가 완료되었습니다.');
+      navigate('/', { replace: true });
+    } catch (error) {
+      const message = error instanceof ApiClientError ? error.message : '회원탈퇴에 실패했습니다.';
+      toast.error(message);
+    } finally {
+      setDeleteLoading(false);
+    }
+  };
+
   return (
     <MainLayout>
-      <div className="bg-[var(--background)] py-8 sm:py-10">
-        <div className="container mx-auto px-4">
+      <div className="bg-[var(--background)] py-10 sm:py-14">
+        <div className="container mx-auto px-4 sm:px-8 max-w-[1080px]">
           <div className="mb-6 flex items-center gap-3">
-            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-blue-50">
-              <User className="h-5 w-5 text-blue-600" />
+            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-blue-50 dark:bg-[rgba(59,130,246,0.14)]">
+              <User className="h-5 w-5 text-blue-600 dark:text-[#93C5FD]" />
             </div>
             <div className="min-w-0">
               <h1 className="text-xl font-semibold text-[var(--foreground)]">계정 설정</h1>
@@ -41,13 +128,17 @@ export function ProfilePage() {
 
           <Tabs
             value={activeTab}
-            onValueChange={(tab) => setSearchParams({ tab }, { replace: true })}
-            className="max-w-2xl"
+            onValueChange={(tab) => {
+              if (isOAuthUser && tab === 'password') return;
+              setSearchParams({ tab }, { replace: true });
+            }}
+            className="max-w-[760px]"
           >
-            <TabsList className="mb-5 grid h-12 w-full grid-cols-2 rounded-2xl bg-white p-1.5 shadow-sm border border-[var(--border)]">
+            <TabsList className="mb-5 grid h-12 w-full grid-cols-2 rounded-2xl bg-white dark:bg-[rgba(15,23,42,0.56)] p-1.5 shadow-sm dark:shadow-none border border-[var(--border)] dark:border-[var(--border-subtle)]">
               <TabsTrigger
                 value="password"
-                className="rounded-xl text-[var(--muted-foreground)] transition-all hover:bg-blue-50 hover:text-blue-700 data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-sm"
+                disabled={isOAuthUser}
+                className="rounded-xl text-[var(--muted-foreground)] transition-all hover:bg-blue-50 hover:text-blue-700 disabled:pointer-events-none disabled:opacity-40 data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-sm"
               >
                 비밀번호 변경
               </TabsTrigger>
@@ -60,43 +151,74 @@ export function ProfilePage() {
             </TabsList>
 
             <TabsContent value="password">
-              <section className="rounded-2xl border border-[var(--border)] bg-white p-5 shadow-sm sm:p-6">
+              <section className="rounded-2xl border border-[var(--border)] dark:border-[var(--border-default)] bg-white dark:bg-[rgba(15,23,42,0.72)] dark:backdrop-blur-xl dark:shadow-[0_20px_60px_rgba(0,0,0,0.20)] p-5 shadow-sm sm:p-6">
                 <div className="mb-6 flex items-start gap-3">
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-50">
-                    <LockKeyhole className="h-5 w-5 text-blue-600" />
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-50 dark:bg-[rgba(59,130,246,0.14)]">
+                    <LockKeyhole className="h-5 w-5 text-blue-600 dark:text-[#93C5FD]" />
                   </div>
                   <div>
                     <h2 className="text-lg font-semibold text-[var(--foreground)]">비밀번호 변경</h2>
-                    <p className="mt-1 text-sm text-[var(--muted-foreground)]">백엔드 API가 준비되면 연결할 예정입니다.</p>
+                    <p className="mt-1 text-sm text-[var(--muted-foreground)]">새 비밀번호는 8자 이상이어야 합니다.</p>
                   </div>
                 </div>
-                <div className="space-y-4">
-                  <Input type="password" placeholder="현재 비밀번호" disabled />
-                  <Input type="password" placeholder="새 비밀번호" disabled />
-                  <Input type="password" placeholder="새 비밀번호 확인" disabled />
-                  <Button disabled className="w-full sm:w-auto">변경하기</Button>
-                </div>
+                <form className="space-y-4" onSubmit={handleChangePassword}>
+                  <Input
+                    type="password"
+                    placeholder="현재 비밀번호"
+                    value={passwordForm.currentPassword}
+                    onChange={(event) => setPasswordForm((current) => ({ ...current, currentPassword: event.target.value }))}
+                    autoComplete="current-password"
+                  />
+                  <Input
+                    type="password"
+                    placeholder="새 비밀번호"
+                    value={passwordForm.newPassword}
+                    onChange={(event) => setPasswordForm((current) => ({ ...current, newPassword: event.target.value }))}
+                    autoComplete="new-password"
+                  />
+                  <Input
+                    type="password"
+                    placeholder="새 비밀번호 확인"
+                    value={passwordForm.confirmPassword}
+                    onChange={(event) => setPasswordForm((current) => ({ ...current, confirmPassword: event.target.value }))}
+                    autoComplete="new-password"
+                  />
+                  <Button type="submit" loading={passwordLoading} className="w-full sm:w-auto">변경하기</Button>
+                </form>
               </section>
             </TabsContent>
 
             <TabsContent value="withdraw">
-              <section className="rounded-2xl border border-red-100 bg-white p-5 shadow-sm sm:p-6">
+              <section className="rounded-2xl border border-red-100 dark:border-[rgba(248,113,113,0.22)] bg-white dark:bg-[rgba(15,23,42,0.72)] dark:backdrop-blur-xl dark:shadow-[0_20px_60px_rgba(0,0,0,0.20)] p-5 shadow-sm sm:p-6">
                 <div className="mb-6 flex items-start gap-3">
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-red-50">
-                    <ShieldAlert className="h-5 w-5 text-red-600" />
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-red-50 dark:bg-[rgba(248,113,113,0.14)]">
+                    <ShieldAlert className="h-5 w-5 text-red-600 dark:text-[#FCA5A5]" />
                   </div>
                   <div>
                     <h2 className="text-lg font-semibold text-[var(--foreground)]">회원탈퇴</h2>
-                    <p className="mt-1 text-sm text-[var(--muted-foreground)]">탈퇴 API가 준비되면 확인 절차와 연결할 예정입니다.</p>
+                    <p className="mt-1 text-sm text-[var(--muted-foreground)]">탈퇴 후 계정 데이터는 복구할 수 없습니다.</p>
                   </div>
                 </div>
-                <div className="rounded-xl border border-red-100 bg-red-50 px-4 py-3 text-sm text-red-700">
-                  저장한 정책, 맞춤 정보, 계정 데이터 삭제 안내 영역입니다.
+                <div className="rounded-xl border border-red-100 bg-red-50 dark:bg-[rgba(248,113,113,0.10)] dark:border-[rgba(248,113,113,0.24)] px-4 py-3 text-sm text-red-700 dark:text-[#FCA5A5]">
+                  저장한 정책, 맞춤 정보, 계정 데이터가 함께 삭제됩니다.
                 </div>
-                <div className="mt-4 space-y-4">
-                  <Input placeholder="탈퇴 확인 문구 입력" disabled />
-                  <Button variant="danger" disabled className="w-full sm:w-auto">탈퇴하기</Button>
-                </div>
+                <form className="mt-4 space-y-4" onSubmit={handleDeleteAccount}>
+                  <Input
+                    placeholder='탈퇴를 원하시면 "탈퇴"라고 작성해 주십시오'
+                    value={deleteForm.confirmText}
+                    onChange={(event) => setDeleteForm((current) => ({ ...current, confirmText: event.target.value }))}
+                  />
+                  {!isOAuthUser && (
+                    <Input
+                      type="password"
+                      placeholder="현재 비밀번호"
+                      value={deleteForm.password}
+                      onChange={(event) => setDeleteForm((current) => ({ ...current, password: event.target.value }))}
+                      autoComplete="current-password"
+                    />
+                  )}
+                  <Button type="submit" variant="danger" loading={deleteLoading} className="w-full sm:w-auto">탈퇴하기</Button>
+                </form>
               </section>
             </TabsContent>
           </Tabs>

--- a/frontend/src/app/pages/SignupPage.tsx
+++ b/frontend/src/app/pages/SignupPage.tsx
@@ -10,11 +10,13 @@ import { Chip } from '../components/atoms/Chip';
 import type { Gender, InterestCategory } from '../types';
 
 const CURRENT_YEAR = 2026;
-
+const MAX_INTERESTS = 2;
 
 const interestCategoryMap: Record<string, InterestCategory> = {
   청년정책: 'youth_policy',
   육아정책: 'childcare_policy',
+  노인정책: 'senior_policy',
+  장애인정책: 'disability_policy',
 };
 
 export function SignupPage() {
@@ -36,7 +38,9 @@ export function SignupPage() {
 
   const interests = [
     { id: '청년정책', label: '청년정책', enabled: true },
-    { id: '육아정책', label: '육아정책 (추후 제공)', enabled: false },
+    { id: '육아정책', label: '육아정책', enabled: true },
+    { id: '노인정책', label: '노인정책', enabled: true },
+    { id: '장애인정책', label: '장애인정책', enabled: true },
   ];
 
   const validateStep1 = () => {
@@ -79,6 +83,14 @@ export function SignupPage() {
       const interestList = formData.interests
         .map((interest) => interestCategoryMap[interest])
         .filter(Boolean) as InterestCategory[];
+      if (interestList.length === 0) {
+        toast.error('관심 분야를 1개 이상 선택해주세요.');
+        return;
+      }
+      if (interestList.length > MAX_INTERESTS) {
+        toast.error(`관심 분야는 최대 ${MAX_INTERESTS}개까지 선택할 수 있습니다.`);
+        return;
+      }
       const age = Math.max(0, CURRENT_YEAR - birthYear);
 
       await signup({
@@ -93,6 +105,15 @@ export function SignupPage() {
       toast.success('인증 메일을 보냈습니다.');
       navigate(getEmailVerificationPath(formData.email));
     } catch (error) {
+      if (
+        error instanceof ApiClientError &&
+        (error.status === 409 || error.message.toLowerCase().includes('conflict'))
+      ) {
+        toast.info('이미 가입 요청된 이메일입니다. 인증 메일을 확인해주세요.');
+        navigate(getEmailVerificationPath(formData.email));
+        return;
+      }
+
       const message = error instanceof ApiClientError ? error.message : '회원가입에 실패했습니다. 다시 시도해주세요.';
       toast.error(message);
     } finally {
@@ -192,11 +213,11 @@ export function SignupPage() {
                     여성
                   </Chip>
                   <Chip
-                    selected={formData.gender === 'other'}
-                    onClick={() => setFormData({ ...formData, gender: 'other' })}
+                    selected={formData.gender === 'unspecified'}
+                    onClick={() => setFormData({ ...formData, gender: 'unspecified' })}
                     className="flex-1"
                   >
-                    기타
+                    선택 안 함
                   </Chip>
                 </div>
               </div>
@@ -218,23 +239,39 @@ export function SignupPage() {
 
               <div>
                 <label className="block mb-3">관심 분야</label>
+                <p className="mb-3 text-xs text-[var(--muted-foreground)]">최대 {MAX_INTERESTS}개까지 선택할 수 있어요.</p>
                 <div className="space-y-2">
                   {interests.map((interest) => (
-                    <div
+                    <button
                       key={interest.id}
-                      className={`p-4 border rounded-xl ${
-                        interest.enabled
-                          ? 'border-[var(--accent)] bg-blue-50'
-                          : 'border-[var(--border)] opacity-50'
+                      type="button"
+                      onClick={() => {
+                        setFormData((current) => ({
+                          ...current,
+                          interests: current.interests.includes(interest.id)
+                            ? current.interests.filter((item) => item !== interest.id)
+                            : current.interests.length >= MAX_INTERESTS
+                              ? current.interests
+                              : [...current.interests, interest.id],
+                        }));
+                        if (
+                          !formData.interests.includes(interest.id) &&
+                          formData.interests.length >= MAX_INTERESTS
+                        ) {
+                          toast.info(`관심 분야는 최대 ${MAX_INTERESTS}개까지 선택할 수 있어요.`);
+                        }
+                      }}
+                      className={`w-full p-4 border rounded-xl text-left transition-colors cursor-pointer ${
+                        formData.interests.includes(interest.id)
+                          ? 'border-[var(--accent)] bg-blue-50 text-[var(--accent)]'
+                          : 'border-[var(--border)] bg-white hover:bg-[var(--muted)]'
                       }`}
                     >
                       <div className="flex items-center justify-between">
                         <span>{interest.label}</span>
-                        {!interest.enabled && (
-                          <span className="text-xs text-[var(--muted-foreground)]">추후 제공</span>
-                        )}
+                        <span className="text-xs text-[var(--muted-foreground)]">선택 가능</span>
                       </div>
-                    </div>
+                    </button>
                   ))}
                 </div>
               </div>

--- a/frontend/src/app/types/api.ts
+++ b/frontend/src/app/types/api.ts
@@ -5,7 +5,9 @@ export interface ApiErrorBody {
 }
 
 export interface ApiErrorResponse {
-  error?: ApiErrorBody;
+  error?: ApiErrorBody | string;
+  message?: string | string[];
+  statusCode?: number;
 }
 
 export interface ListResponse<T> {
@@ -17,7 +19,15 @@ export interface RequestOptions {
   method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
   body?: unknown;
   headers?: HeadersInit;
-  query?: Record<string, string | number | boolean | undefined | null>;
+  query?: Record<
+    string,
+    | string
+    | number
+    | boolean
+    | Array<string | number | boolean>
+    | undefined
+    | null
+  >;
   auth?: boolean;
   signal?: AbortSignal;
 }

--- a/frontend/src/app/types/index.ts
+++ b/frontend/src/app/types/index.ts
@@ -27,7 +27,7 @@ export interface User {
   name: string;
   email: string;
   age: number;
-  gender?: 'male' | 'female' | 'other';
+  gender?: 'male' | 'female' | 'unspecified';
   region: string;
   interests: string[];
 }

--- a/frontend/src/app/types/policy.ts
+++ b/frontend/src/app/types/policy.ts
@@ -11,6 +11,7 @@ export type PolicyType = 'application' | 'info';
 export interface GetPoliciesParams {
   search?: string;
   interest?: InterestCategory;
+  interests?: InterestCategory[];
   regionCode?: RegionCode;
   sortBy?: PolicySortBy;
   order?: SortOrder;
@@ -31,6 +32,8 @@ export interface PolicyListItem {
   endsAt: string | null;
   isAlwaysOpen: boolean;
   periodRaw?: string | null;
+  policyType?: PolicyType;
+  targetDescription?: string | null;
   fitScore?: number | null;
   sourceType?: SourceType;
   userState?: UserPolicyState | null;
@@ -49,6 +52,7 @@ export interface PolicyEligibilityInfo {
   supportContent?: string | null;
   selectionCriteria?: string | null;
   applicationDeadline?: string | null;
+  warnBox?: string | null;
 }
 
 export interface LastEligibilitySummary {
@@ -78,6 +82,7 @@ export interface PolicyDetail {
   periodRaw?: string | null;
   minAge?: number | null;
   maxAge?: number | null;
+  targetDescription?: string | null;
   requirements?: PolicyRequirement[];
   eligibilityInfo?: PolicyEligibilityInfo | null;
   eligibilityCompleteness?: EligibilityCompleteness | null;
@@ -102,9 +107,9 @@ export interface EligibilityResponse {
   result: EligibilityResult;
   reasons: string[];
   explanation: string;
-  policy: EligibilityPolicySummary;
+  policy?: EligibilityPolicySummary;
   eligibilityCompleteness?: EligibilityCompleteness | null;
-  checkedAt: string;
+  checkedAt?: string;
 }
 
 export interface UpdateMyPolicyStateRequest {
@@ -118,7 +123,21 @@ export interface MyPolicyItem {
   providerName: string;
   shortDescription?: string;
   categories?: InterestCategory[];
+  startsAt?: string | null;
+  endsAt?: string | null;
+  isAlwaysOpen?: boolean;
+  periodRaw?: string | null;
+  targetDescription?: string | null;
   sourceType?: SourceType;
+  state: UserPolicyState;
+  note: string | null;
+  appliedAt: string | null;
+  updatedAt: string;
+}
+
+export interface UpdatedMyPolicyState {
+  id: string;
+  policyId: string;
   state: UserPolicyState;
   note: string | null;
   appliedAt: string | null;

--- a/frontend/src/app/types/user.ts
+++ b/frontend/src/app/types/user.ts
@@ -1,4 +1,4 @@
-export type Gender = 'male' | 'female' | 'other' | 'unspecified';
+export type Gender = 'male' | 'female' | 'unspecified';
 
 export type RegionCode =
   | 'seoul'
@@ -28,7 +28,11 @@ export type RegionCode =
   | 'seoul_jung'
   | 'seoul_jungnang';
 
-export type InterestCategory = 'youth_policy' | 'childcare_policy';
+export type InterestCategory =
+  | 'youth_policy'
+  | 'childcare_policy'
+  | 'senior_policy'
+  | 'disability_policy';
 
 export interface UserProfileSummary {
   userId: string;
@@ -56,6 +60,23 @@ export interface CompleteProfileRequest {
   gender: Gender;
   regionCode: RegionCode;
   interests: InterestCategory[];
+}
+
+export interface UpdateProfileRequest {
+  age?: number;
+  gender?: Gender;
+  regionCode?: RegionCode;
+  interests?: InterestCategory[];
+  displayName?: string;
+}
+
+export interface ChangePasswordRequest {
+  currentPassword: string;
+  newPassword: string;
+}
+
+export interface DeleteAccountRequest {
+  password?: string;
 }
 
 export interface LoginRequest {

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -39,7 +39,7 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
-  
+
   /* Policy-specific colors */
   --success: #10b981;
   --success-foreground: #ffffff;
@@ -47,49 +47,113 @@
   --warning-foreground: #ffffff;
   --info: #3b82f6;
   --info-foreground: #ffffff;
-  
+
   /* Typography scale */
-  --text-xs: 0.8125rem;    /* 13px */
-  --text-sm: 0.875rem;      /* 14px */
-  --text-base: 0.9375rem;   /* 15px */
-  --text-lg: 1.125rem;      /* 18px */
-  --text-xl: 1.375rem;      /* 22px */
-  --text-2xl: 1.875rem;     /* 30px */
-  --text-3xl: 2.25rem;      /* 36px */
-  --text-4xl: 2.875rem;     /* 46px */
-  
-  /* Line heights */
+  --text-xs: 0.8125rem;
+  --text-sm: 0.875rem;
+  --text-base: 0.9375rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.375rem;
+  --text-2xl: 1.875rem;
+  --text-3xl: 2.25rem;
+  --text-4xl: 2.875rem;
+
   --leading-tight: 1.25;
   --leading-snug: 1.4;
   --leading-normal: 1.6;
   --leading-relaxed: 1.75;
-  
-  /* Letter spacing */
+
   --tracking-tight: -0.02em;
   --tracking-normal: -0.01em;
   --tracking-wide: 0;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.145 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.145 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
-  --border: oklch(0.269 0 0);
-  --input: oklch(0.269 0 0);
-  --ring: oklch(0.439 0 0);
+  /* Background — charcoal navy, not pure black */
+  --bg-main: #070B12;
+  --bg-hero: #080E18;
+  --bg-header: rgba(8, 13, 23, 0.82);
+
+  /* Surfaces */
+  --surface-0: #0A101B;
+  --surface-1: #0F172A;
+  --surface-2: #111C31;
+  --surface-3: #172033;
+
+  /* Cards (translucent glass over bg-main, not a solid navy slab) */
+  --card-bg: rgba(15, 23, 42, 0.78);
+  --card-bg-solid: #111827;
+  --card-bg-hover: rgba(30, 41, 59, 0.86);
+
+  --policy-card-surface: #0F172A;
+  --policy-card-open-tint: rgba(16, 185, 129, 0.115);
+  --policy-card-open-tint-hover: rgba(16, 185, 129, 0.145);
+  --policy-card-open-border: rgba(52, 211, 153, 0.38);
+  --policy-card-open-border-hover: rgba(52, 211, 153, 0.50);
+  --policy-card-always-tint: rgba(59, 130, 246, 0.115);
+  --policy-card-always-tint-hover: rgba(59, 130, 246, 0.145);
+  --policy-card-always-border: rgba(96, 165, 250, 0.36);
+  --policy-card-always-border-hover: rgba(96, 165, 250, 0.48);
+  --policy-card-check-tint: rgba(20, 184, 166, 0.115);
+  --policy-card-check-tint-hover: rgba(20, 184, 166, 0.145);
+  --policy-card-check-border: rgba(45, 212, 191, 0.36);
+  --policy-card-check-border-hover: rgba(45, 212, 191, 0.48);
+  --policy-card-unknown-tint: rgba(245, 158, 11, 0.13);
+  --policy-card-unknown-tint-hover: rgba(245, 158, 11, 0.16);
+  --policy-card-unknown-border: rgba(251, 191, 36, 0.42);
+  --policy-card-unknown-border-hover: rgba(251, 191, 36, 0.54);
+  --policy-card-closed-tint: rgba(100, 116, 139, 0.11);
+  --policy-card-closed-tint-hover: rgba(100, 116, 139, 0.14);
+  --policy-card-closed-border: rgba(148, 163, 184, 0.28);
+  --policy-card-closed-border-hover: rgba(148, 163, 184, 0.38);
+
+  /* Borders */
+  --border-subtle: rgba(148, 163, 184, 0.10);
+  --border-default: rgba(148, 163, 184, 0.18);
+  --border-strong: rgba(148, 163, 184, 0.28);
+  --border-active: rgba(96, 165, 250, 0.42);
+
+  /* Text */
+  --text-primary: #F8FAFC;
+  --text-secondary: #CBD5E1;
+  --text-muted: #94A3B8;
+  --text-disabled: #64748B;
+
+  /* Brand */
+  --primary-color: #3B82F6;
+  --primary-hover: #60A5FA;
+  --primary-soft: rgba(59, 130, 246, 0.12);
+  --purple-color: #8B5CF6;
+  --purple-soft: rgba(139, 92, 246, 0.14);
+  --success-color: #34D399;
+  --success-soft: rgba(52, 211, 153, 0.12);
+  --warning-color: #FBBF24;
+  --warning-soft: rgba(251, 191, 36, 0.12);
+  --danger-color: #F87171;
+  --danger-soft: rgba(248, 113, 113, 0.12);
+
+  /* Legacy semantic tokens (kept for shadcn UI primitives) */
+  --background: var(--bg-main);
+  --foreground: var(--text-primary);
+  --card: var(--surface-1);
+  --card-foreground: var(--text-primary);
+  --popover: var(--surface-2);
+  --popover-foreground: var(--text-primary);
+  --primary: var(--text-primary);
+  --primary-foreground: #0B0F17;
+  --secondary: var(--surface-2);
+  --secondary-foreground: var(--text-primary);
+  --muted: var(--surface-2);
+  --muted-foreground: var(--text-muted);
+  --accent: var(--primary-color);
+  --accent-foreground: #FFFFFF;
+  --destructive: var(--danger-color);
+  --destructive-foreground: #FFFFFF;
+  --border: var(--border-default);
+  --input: var(--surface-2);
+  --input-background: var(--surface-2);
+  --switch-background: #4b5563;
+  --ring: var(--primary-color);
   --font-weight-medium: 500;
   --font-weight-normal: 400;
   --chart-1: oklch(0.488 0.243 264.376);
@@ -97,14 +161,14 @@
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(0.269 0 0);
-  --sidebar-ring: oklch(0.439 0 0);
+  --sidebar: var(--surface-1);
+  --sidebar-foreground: var(--text-primary);
+  --sidebar-primary: var(--primary-color);
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: var(--surface-2);
+  --sidebar-accent-foreground: var(--text-primary);
+  --sidebar-border: var(--border-default);
+  --sidebar-ring: var(--primary-color);
 }
 
 @theme inline {
@@ -161,106 +225,882 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
-  /**
-  * Default typography styles for HTML elements (h1-h4, p, label, button, input).
-  * These are in @layer base, so Tailwind utility classes (like text-sm, text-lg) automatically override them.
-  */
+  .dark {
+    color-scheme: dark;
+  }
 
   html {
     font-size: var(--font-size);
   }
 
-  h1 {
-    font-size: var(--text-2xl);
-    font-weight: 600;
-    line-height: var(--leading-snug);
-    letter-spacing: var(--tracking-tight);
-  }
+  h1 { font-size: var(--text-2xl); font-weight: 600; line-height: var(--leading-snug); letter-spacing: var(--tracking-tight); }
+  h2 { font-size: var(--text-xl); font-weight: 600; line-height: var(--leading-snug); letter-spacing: var(--tracking-tight); }
+  h3 { font-size: var(--text-lg); font-weight: 600; line-height: var(--leading-normal); letter-spacing: var(--tracking-normal); }
+  h4 { font-size: var(--text-base); font-weight: 600; line-height: var(--leading-normal); letter-spacing: var(--tracking-normal); }
+  p  { line-height: var(--leading-relaxed); letter-spacing: var(--tracking-normal); }
+  label  { font-size: var(--text-sm); font-weight: var(--font-weight-medium); line-height: var(--leading-normal); }
+  button { font-size: var(--text-sm); font-weight: var(--font-weight-medium); line-height: var(--leading-normal); letter-spacing: var(--tracking-wide); }
+  input  { font-size: var(--text-base); font-weight: var(--font-weight-normal); line-height: var(--leading-normal); }
+}
 
-  h2 {
-    font-size: var(--text-xl);
-    font-weight: 600;
-    line-height: var(--leading-snug);
-    letter-spacing: var(--tracking-tight);
-  }
+/* ─────────────────────────────────────────────────────────────────────────
+   Narrow dark-mode bridge
+   Only what's needed so components without explicit `dark:` variants don't
+   look broken. Anything component-level should use `dark:` utilities instead
+   of being routed through this bridge.
+   ───────────────────────────────────────────────────────────────────────── */
 
-  h3 {
-    font-size: var(--text-lg);
-    font-weight: 600;
-    line-height: var(--leading-normal);
-    letter-spacing: var(--tracking-normal);
-  }
+.dark body {
+  background-color: var(--bg-main);
+  color: var(--text-primary);
+}
 
-  h4 {
-    font-size: var(--text-base);
-    font-weight: 600;
-    line-height: var(--leading-normal);
-    letter-spacing: var(--tracking-normal);
-  }
+/* `bg-white` falls back to a glass card surface, NOT a solid slab. No
+   !important so any `dark:bg-…` on a component wins. */
+.dark .bg-white {
+  background-color: var(--card-bg);
+}
 
-  p {
-    line-height: var(--leading-relaxed);
-    letter-spacing: var(--tracking-normal);
-  }
+/* Common pastel chip/badge backgrounds — soft tones in dark mode */
+.dark .bg-blue-50,
+.dark .bg-blue-50\/30,
+.dark .bg-blue-50\/40,
+.dark .bg-blue-50\/50,
+.dark .bg-blue-50\/60 {
+  background-color: rgba(59, 130, 246, 0.10);
+}
 
-  label {
-    font-size: var(--text-sm);
-    font-weight: var(--font-weight-medium);
-    line-height: var(--leading-normal);
-  }
+.dark .bg-indigo-50,
+.dark .bg-purple-50,
+.dark .bg-violet-50 {
+  background-color: rgba(139, 92, 246, 0.10);
+}
 
-  button {
-    font-size: var(--text-sm);
-    font-weight: var(--font-weight-medium);
-    line-height: var(--leading-normal);
-    letter-spacing: var(--tracking-wide);
-  }
+.dark .bg-emerald-50,
+.dark .bg-emerald-50\/40 {
+  background-color: rgba(52, 211, 153, 0.10);
+}
 
-  input {
-    font-size: var(--text-base);
-    font-weight: var(--font-weight-normal);
-    line-height: var(--leading-normal);
-  }
+.dark .bg-amber-50,
+.dark .bg-amber-50\/60,
+.dark .bg-yellow-50,
+.dark .bg-orange-50 {
+  background-color: rgba(251, 191, 36, 0.10);
+}
+
+.dark .bg-red-50 {
+  background-color: rgba(248, 113, 113, 0.10);
+}
+
+.dark .bg-gray-50,
+.dark .bg-gray-50\/60,
+.dark .bg-gray-100,
+.dark .bg-slate-50,
+.dark .bg-slate-100 {
+  background-color: var(--surface-2);
+}
+
+.dark .bg-blue-100,
+.dark .bg-blue-200 {
+  background-color: rgba(96, 165, 250, 0.16);
+}
+
+.dark .bg-emerald-100,
+.dark .bg-emerald-200 {
+  background-color: rgba(52, 211, 153, 0.16);
+}
+
+.dark .bg-amber-100,
+.dark .bg-amber-200,
+.dark .bg-yellow-100 {
+  background-color: rgba(251, 191, 36, 0.16);
+}
+
+.dark .bg-violet-100,
+.dark .bg-purple-100 {
+  background-color: rgba(139, 92, 246, 0.16);
+}
+
+.dark .bg-orange-100 {
+  background-color: rgba(251, 146, 60, 0.14);
+}
+
+.dark .bg-red-100 {
+  background-color: rgba(248, 113, 113, 0.14);
+}
+
+/* Pastel section gradients → fade through deep navy, not pastel tints */
+.dark .to-white {
+  --tw-gradient-to: var(--bg-main) var(--tw-gradient-to-position);
+}
+
+.dark .from-white {
+  --tw-gradient-from: var(--bg-main) var(--tw-gradient-from-position);
+  --tw-gradient-to: rgba(7, 11, 18, 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+}
+
+.dark .to-slate-50,
+.dark .from-slate-50 {
+  --tw-gradient-to: var(--bg-main) var(--tw-gradient-to-position);
+  --tw-gradient-from: var(--bg-main) var(--tw-gradient-from-position);
+}
+
+.dark .from-blue-50,
+.dark .from-blue-50\/50 {
+  --tw-gradient-from: rgba(59, 130, 246, 0.08) var(--tw-gradient-from-position);
+}
+
+.dark .via-indigo-50 {
+  --tw-gradient-via: rgba(99, 102, 241, 0.08) var(--tw-gradient-via-position);
+  --tw-gradient-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+}
+
+.dark .via-purple-50,
+.dark .via-purple-50\/30 {
+  --tw-gradient-via: rgba(139, 92, 246, 0.08) var(--tw-gradient-via-position);
+  --tw-gradient-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+}
+
+.dark .to-purple-50 {
+  --tw-gradient-to: rgba(139, 92, 246, 0.08) var(--tw-gradient-to-position);
+}
+
+.dark .from-blue-100,
+.dark .via-purple-100,
+.dark .to-blue-100 {
+  --tw-gradient-from: rgba(59, 130, 246, 0.10) var(--tw-gradient-from-position);
+  --tw-gradient-via: rgba(139, 92, 246, 0.10) var(--tw-gradient-via-position);
+  --tw-gradient-to: rgba(59, 130, 246, 0.10) var(--tw-gradient-to-position);
+}
+
+/* Text colors */
+.dark .text-gray-400,
+.dark .text-gray-500,
+.dark .text-gray-600,
+.dark .text-slate-400,
+.dark .text-slate-500,
+.dark .text-slate-600 {
+  color: var(--text-muted);
+}
+
+.dark .text-gray-700,
+.dark .text-gray-800,
+.dark .text-gray-900,
+.dark .text-slate-700,
+.dark .text-slate-800,
+.dark .text-slate-900 {
+  color: var(--text-primary);
+}
+
+.dark .text-blue-600,
+.dark .text-blue-700,
+.dark .text-blue-800,
+.dark .text-blue-900 {
+  color: #93C5FD;
+}
+
+.dark .text-purple-600,
+.dark .text-purple-700,
+.dark .text-violet-700 {
+  color: #C4B5FD;
+}
+
+.dark .text-emerald-600,
+.dark .text-emerald-700,
+.dark .text-emerald-800 {
+  color: #6EE7B7;
+}
+
+.dark .text-amber-600,
+.dark .text-amber-700,
+.dark .text-orange-600,
+.dark .text-orange-700,
+.dark .text-amber-800 {
+  color: #FCD34D;
+}
+
+.dark .text-red-600,
+.dark .text-red-700 {
+  color: #FCA5A5;
+}
+
+.dark .text-\[\#007A7A\],
+.dark .text-\[\#006B6B\] {
+  color: #5EEAD4;
+}
+
+/* Borders */
+.dark .border-white\/80,
+.dark .border-gray-100,
+.dark .border-gray-200,
+.dark .border-gray-300,
+.dark .border-slate-100,
+.dark .border-slate-200,
+.dark .border-slate-300 {
+  border-color: var(--border-default);
+}
+
+.dark .border-blue-100,
+.dark .border-blue-100\/80,
+.dark .border-blue-200,
+.dark .border-blue-200\/50 {
+  border-color: rgba(96, 165, 250, 0.20);
+}
+
+.dark .border-emerald-200 {
+  border-color: rgba(52, 211, 153, 0.20);
+}
+
+.dark .border-amber-200,
+.dark .border-orange-200,
+.dark .border-yellow-200 {
+  border-color: rgba(251, 191, 36, 0.20);
+}
+
+.dark .border-violet-200,
+.dark .border-purple-200 {
+  border-color: rgba(196, 181, 253, 0.20);
+}
+
+/* Strong saturated card borders used for PolicyCard status indicators —
+   soften to subtle default. Hover routes back to the brand-blue active ring
+   so hover state still feels distinct. */
+.dark .border-emerald-500,
+.dark .border-emerald-600,
+.dark .border-blue-500,
+.dark .border-blue-600,
+.dark .border-gray-500,
+.dark .border-gray-600,
+.dark .border-amber-500,
+.dark .border-amber-600,
+.dark .border-violet-500,
+.dark .border-orange-500 {
+  border-color: var(--border-default);
+}
+
+.dark .border-red-500 {
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+.dark .hover\:border-emerald-600:hover,
+.dark .hover\:border-blue-600:hover,
+.dark .hover\:border-gray-600:hover,
+.dark .hover\:border-amber-600:hover,
+.dark .hover\:border-red-600:hover {
+  border-color: var(--border-active);
+}
+
+.dark .border-red-100,
+.dark .border-red-200 {
+  border-color: rgba(248, 113, 113, 0.22);
+}
+
+/* PolicyCard pastel tints (recruiting/always/closed) — neutralize to glass.
+   The colored border is what carries the status in dark mode, paired with the
+   bridge above that maps it to a subtle slate. */
+.dark .bg-emerald-50\/40,
+.dark .bg-blue-50\/40,
+.dark .bg-gray-50\/60,
+.dark .bg-amber-50\/60 {
+  background-color: var(--card-bg);
+}
+
+/* Custom teal accent (periodRaw status) */
+.dark .bg-\[\#00FFFF\]\/10,
+.dark .bg-\[\#00FFFF\]\/20,
+.dark .bg-\[\#00FFFF\]\/25 {
+  background-color: rgba(45, 212, 191, 0.12);
+}
+
+.dark .border-\[\#00D9D9\]\/60,
+.dark .border-\[\#00D9D9\] {
+  border-color: rgba(94, 234, 212, 0.28);
+}
+
+.dark .hover\:bg-\[\#00FFFF\]\/20:hover {
+  background-color: rgba(45, 212, 191, 0.22);
+}
+
+/* Hover normalizations */
+.dark .hover\:bg-blue-50:hover,
+.dark .hover\:bg-gray-50:hover,
+.dark .hover\:bg-slate-50:hover {
+  background-color: var(--surface-3);
+}
+
+.dark .hover\:text-blue-700:hover,
+.dark .hover\:text-gray-700:hover,
+.dark .hover\:text-slate-700:hover {
+  color: var(--text-primary);
+}
+
+/* Inputs — clear contrast vs cards, visible focus ring */
+.dark input,
+.dark textarea,
+.dark select,
+.dark input.bg-white,
+.dark textarea.bg-white {
+  background-color: var(--surface-2);
+  color: var(--text-primary);
+  border-color: var(--border-default);
+}
+
+.dark input::placeholder,
+.dark textarea::placeholder {
+  color: var(--text-muted);
+}
+
+.dark input:focus,
+.dark input:focus-visible,
+.dark textarea:focus,
+.dark textarea:focus-visible,
+.dark select:focus,
+.dark select:focus-visible {
+  border-color: var(--border-active);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.14);
+  outline: none;
+}
+
+/* Dialog/modal overlay slightly stronger on dark */
+.dark .bg-black\/30 {
+  background-color: rgba(0, 0, 0, 0.55);
+}
+
+/* Smooth interaction transitions */
+.dark a,
+.dark button,
+.dark [role="button"] {
+  transition-property: background-color, border-color, color, box-shadow, transform;
+  transition-duration: 160ms;
+  transition-timing-function: ease;
+}
+
+/* Policies page dark-mode color correction only. No layout or structure changes. */
+.dark [data-page="policies"] {
+  --policies-bg: #070B12;
+  --policies-panel-bg: #080E18;
+
+  --policies-card-bg: #0F172A;
+  --policies-card-bg-hover: #111C31;
+  --policies-card-border: rgba(148, 163, 184, 0.20);
+  --policies-card-border-hover: rgba(96, 165, 250, 0.42);
+
+  --policies-input-bg: #101827;
+  --policies-input-border: rgba(148, 163, 184, 0.28);
+  --policies-input-text: #F8FAFC;
+  --policies-placeholder: #94A3B8;
+
+  --policies-text-primary: #F8FAFC;
+  --policies-text-secondary: #CBD5E1;
+  --policies-text-muted: #94A3B8;
+
+  --policies-blue-bg: rgba(59, 130, 246, 0.18);
+  --policies-blue-border: rgba(96, 165, 250, 0.46);
+  --policies-blue-text: #93C5FD;
+
+  --policies-green-bg: rgba(16, 185, 129, 0.17);
+  --policies-green-border: rgba(52, 211, 153, 0.44);
+  --policies-green-text: #6EE7B7;
+
+  --policies-teal-bg: rgba(20, 184, 166, 0.17);
+  --policies-teal-border: rgba(45, 212, 191, 0.44);
+  --policies-teal-text: #5EEAD4;
+
+  --policies-amber-bg: rgba(245, 158, 11, 0.18);
+  --policies-amber-border: rgba(251, 191, 36, 0.48);
+  --policies-amber-text: #FCD34D;
+
+  --policies-orange-bg: rgba(249, 115, 22, 0.17);
+  --policies-orange-border: rgba(251, 146, 60, 0.46);
+  --policies-orange-text: #FDBA74;
+
+  --policies-violet-bg: rgba(139, 92, 246, 0.17);
+  --policies-violet-border: rgba(167, 139, 250, 0.46);
+  --policies-violet-text: #C4B5FD;
+
+  --policies-sky-bg: rgba(14, 165, 233, 0.17);
+  --policies-sky-border: rgba(56, 189, 248, 0.44);
+  --policies-sky-text: #7DD3FC;
+
+  --policies-neutral-bg: rgba(148, 163, 184, 0.13);
+  --policies-neutral-border: rgba(148, 163, 184, 0.32);
+  --policies-neutral-text: #CBD5E1;
+
+  --foreground: var(--policies-text-primary);
+  --muted-foreground: var(--policies-text-muted);
+  --border: var(--policies-card-border);
+  --secondary: var(--policies-neutral-bg);
+  --secondary-foreground: var(--policies-neutral-text);
+
+  background-color: var(--policies-bg);
+  color: var(--policies-text-primary);
+}
+
+.dark [data-page="policies"].backdrop-blur-xl {
+  background-color: var(--policies-panel-bg);
+  border-color: var(--policies-card-border);
+}
+
+.dark [data-page="policies"] article.group.relative.border.rounded-3xl {
+  background-color: var(--policies-card-bg);
+  border-color: var(--policies-card-border);
+}
+
+.dark [data-page="policies"] article.group.relative.border.rounded-3xl:hover {
+  background-color: var(--policies-card-bg-hover);
+  border-color: var(--policies-card-border-hover);
+}
+
+.dark [data-page="policies"] article.bg-emerald-50\/40,
+.dark [data-page="policies"] article.bg-blue-50\/40,
+.dark [data-page="policies"] article.bg-gray-50\/60,
+.dark [data-page="policies"] article.bg-amber-50\/60,
+.dark [data-page="policies"] article.bg-\[\#00FFFF\]\/10 {
+  background-color: var(--policies-card-bg);
+}
+
+.dark [data-page="policies"] article.bg-emerald-50\/40:hover,
+.dark [data-page="policies"] article.bg-blue-50\/40:hover,
+.dark [data-page="policies"] article.bg-gray-50\/60:hover,
+.dark [data-page="policies"] article.bg-amber-50\/60:hover,
+.dark [data-page="policies"] article.bg-\[\#00FFFF\]\/10:hover {
+  background-color: var(--policies-card-bg-hover);
+}
+
+.dark [data-page="policies"] input,
+.dark [data-page="policies"] select,
+.dark [data-page="policies"] button.bg-white,
+.dark [data-page="policies"] .bg-white {
+  background-color: var(--policies-input-bg);
+  border-color: var(--policies-input-border);
+  color: var(--policies-input-text);
+}
+
+.dark [data-page="policies"] input::placeholder,
+.dark [data-page="policies"] textarea::placeholder {
+  color: var(--policies-placeholder);
+}
+
+.dark [data-page="policies"] input:focus,
+.dark [data-page="policies"] input:focus-visible,
+.dark [data-page="policies"] select:focus,
+.dark [data-page="policies"] select:focus-visible,
+.dark [data-page="policies"] button.bg-white:focus,
+.dark [data-page="policies"] button.bg-white:focus-visible {
+  border-color: var(--policies-blue-border);
+  outline-color: var(--policies-blue-border);
+  --tw-ring-color: rgba(96, 165, 250, 0.24);
+}
+
+.dark [data-page="policies"] .bg-emerald-50,
+.dark [data-page="policies"] .bg-emerald-100,
+.dark [data-page="policies"] .bg-emerald-200,
+.dark [data-page="policies"] .bg-green-50,
+.dark [data-page="policies"] .bg-green-100,
+.dark [data-page="policies"] .bg-green-200 {
+  background-color: var(--policies-green-bg);
+}
+
+.dark [data-page="policies"] .bg-emerald-500,
+.dark [data-page="policies"] .bg-green-500 {
+  background-color: var(--policies-green-text);
+}
+
+.dark [data-page="policies"] .text-emerald-600,
+.dark [data-page="policies"] .text-emerald-700,
+.dark [data-page="policies"] .text-emerald-800,
+.dark [data-page="policies"] .text-green-600,
+.dark [data-page="policies"] .text-green-700,
+.dark [data-page="policies"] .text-green-800 {
+  color: var(--policies-green-text);
+}
+
+.dark [data-page="policies"] .border-emerald-200,
+.dark [data-page="policies"] .border-emerald-300,
+.dark [data-page="policies"] .border-emerald-400,
+.dark [data-page="policies"] .border-emerald-500,
+.dark [data-page="policies"] .border-green-200,
+.dark [data-page="policies"] .border-green-300,
+.dark [data-page="policies"] .border-green-400,
+.dark [data-page="policies"] .border-green-500,
+.dark [data-page="policies"] article.border-emerald-500 {
+  border-color: var(--policies-green-border);
+}
+
+.dark [data-page="policies"] article.hover\:border-emerald-600:hover {
+  border-color: var(--policies-green-border);
+}
+
+.dark [data-page="policies"] .bg-blue-50,
+.dark [data-page="policies"] .bg-blue-100,
+.dark [data-page="policies"] .bg-blue-200 {
+  background-color: var(--policies-blue-bg);
+}
+
+.dark [data-page="policies"] .bg-blue-500 {
+  background-color: var(--policies-blue-text);
+}
+
+.dark [data-page="policies"] .text-blue-600,
+.dark [data-page="policies"] .text-blue-700,
+.dark [data-page="policies"] .text-blue-800 {
+  color: var(--policies-blue-text);
+}
+
+.dark [data-page="policies"] .border-blue-200,
+.dark [data-page="policies"] .border-blue-300,
+.dark [data-page="policies"] .border-blue-400,
+.dark [data-page="policies"] .border-blue-500,
+.dark [data-page="policies"] article.border-blue-500 {
+  border-color: var(--policies-blue-border);
+}
+
+.dark [data-page="policies"] article.hover\:border-blue-600:hover {
+  border-color: var(--policies-blue-border);
+}
+
+.dark [data-page="policies"] .bg-teal-50,
+.dark [data-page="policies"] .bg-teal-100,
+.dark [data-page="policies"] .bg-cyan-50,
+.dark [data-page="policies"] .bg-cyan-100,
+.dark [data-page="policies"] .bg-\[\#00FFFF\]\/10,
+.dark [data-page="policies"] .bg-\[\#00FFFF\]\/20,
+.dark [data-page="policies"] .bg-\[\#00FFFF\]\/25 {
+  background-color: var(--policies-teal-bg);
+}
+
+.dark [data-page="policies"] .bg-\[\#00D9D9\] {
+  background-color: var(--policies-teal-text);
+}
+
+.dark [data-page="policies"] .text-teal-600,
+.dark [data-page="policies"] .text-teal-700,
+.dark [data-page="policies"] .text-cyan-600,
+.dark [data-page="policies"] .text-cyan-700,
+.dark [data-page="policies"] .text-\[\#007A7A\],
+.dark [data-page="policies"] .text-\[\#006B6B\] {
+  color: var(--policies-teal-text);
+}
+
+.dark [data-page="policies"] .border-teal-200,
+.dark [data-page="policies"] .border-teal-300,
+.dark [data-page="policies"] .border-cyan-200,
+.dark [data-page="policies"] .border-cyan-300,
+.dark [data-page="policies"] .border-\[\#00D9D9\],
+.dark [data-page="policies"] .border-\[\#00D9D9\]\/60,
+.dark [data-page="policies"] article.border-\[\#00D9D9\] {
+  border-color: var(--policies-teal-border);
+}
+
+.dark [data-page="policies"] article.hover\:border-\[\#00BDBD\]:hover {
+  border-color: var(--policies-teal-border);
+}
+
+.dark [data-page="policies"] .hover\:bg-\[\#00FFFF\]\/20:hover {
+  background-color: var(--policies-teal-bg);
+}
+
+.dark [data-page="policies"] .bg-amber-50,
+.dark [data-page="policies"] .bg-amber-100,
+.dark [data-page="policies"] .bg-amber-200,
+.dark [data-page="policies"] .bg-yellow-50,
+.dark [data-page="policies"] .bg-yellow-100,
+.dark [data-page="policies"] .bg-yellow-200 {
+  background-color: var(--policies-amber-bg);
+}
+
+.dark [data-page="policies"] .bg-amber-500,
+.dark [data-page="policies"] .bg-yellow-500 {
+  background-color: var(--policies-amber-text);
+}
+
+.dark [data-page="policies"] .text-amber-600,
+.dark [data-page="policies"] .text-amber-700,
+.dark [data-page="policies"] .text-amber-800,
+.dark [data-page="policies"] .text-yellow-600,
+.dark [data-page="policies"] .text-yellow-700,
+.dark [data-page="policies"] .text-yellow-800 {
+  color: var(--policies-amber-text);
+}
+
+.dark [data-page="policies"] .border-amber-200,
+.dark [data-page="policies"] .border-amber-300,
+.dark [data-page="policies"] .border-amber-400,
+.dark [data-page="policies"] .border-amber-500,
+.dark [data-page="policies"] .border-yellow-200,
+.dark [data-page="policies"] .border-yellow-300,
+.dark [data-page="policies"] .border-yellow-400,
+.dark [data-page="policies"] .border-yellow-500,
+.dark [data-page="policies"] article.border-amber-500 {
+  border-color: var(--policies-amber-border);
+}
+
+.dark [data-page="policies"] article.hover\:border-amber-600:hover {
+  border-color: var(--policies-amber-border);
+}
+
+.dark [data-page="policies"] .bg-orange-50,
+.dark [data-page="policies"] .bg-orange-100 {
+  background-color: var(--policies-orange-bg);
+}
+
+.dark [data-page="policies"] .bg-orange-500 {
+  background-color: var(--policies-orange-text);
+}
+
+.dark [data-page="policies"] .text-orange-600,
+.dark [data-page="policies"] .text-orange-700 {
+  color: var(--policies-orange-text);
+}
+
+.dark [data-page="policies"] .border-orange-200,
+.dark [data-page="policies"] .border-orange-300,
+.dark [data-page="policies"] .border-orange-500 {
+  border-color: var(--policies-orange-border);
+}
+
+.dark [data-page="policies"] .bg-violet-50,
+.dark [data-page="policies"] .bg-violet-100,
+.dark [data-page="policies"] .bg-purple-50,
+.dark [data-page="policies"] .bg-purple-100 {
+  background-color: var(--policies-violet-bg);
+}
+
+.dark [data-page="policies"] .bg-violet-500,
+.dark [data-page="policies"] .bg-purple-500 {
+  background-color: var(--policies-violet-text);
+}
+
+.dark [data-page="policies"] .text-violet-600,
+.dark [data-page="policies"] .text-violet-700,
+.dark [data-page="policies"] .text-purple-600,
+.dark [data-page="policies"] .text-purple-700 {
+  color: var(--policies-violet-text);
+}
+
+.dark [data-page="policies"] .border-violet-200,
+.dark [data-page="policies"] .border-violet-300,
+.dark [data-page="policies"] .border-violet-500,
+.dark [data-page="policies"] .border-purple-200,
+.dark [data-page="policies"] .border-purple-300,
+.dark [data-page="policies"] .border-purple-500 {
+  border-color: var(--policies-violet-border);
+}
+
+.dark [data-page="policies"] .bg-sky-50,
+.dark [data-page="policies"] .bg-sky-100 {
+  background-color: var(--policies-sky-bg);
+}
+
+.dark [data-page="policies"] .text-sky-600,
+.dark [data-page="policies"] .text-sky-700 {
+  color: var(--policies-sky-text);
+}
+
+.dark [data-page="policies"] .border-sky-200,
+.dark [data-page="policies"] .border-sky-300 {
+  border-color: var(--policies-sky-border);
+}
+
+.dark [data-page="policies"] .bg-slate-50,
+.dark [data-page="policies"] .bg-slate-100,
+.dark [data-page="policies"] .bg-gray-50,
+.dark [data-page="policies"] .bg-gray-100,
+.dark [data-page="policies"] .bg-gray-200,
+.dark [data-page="policies"] [class*="bg-[var(--secondary)]"] {
+  background-color: var(--policies-neutral-bg);
+}
+
+.dark [data-page="policies"] .text-slate-600,
+.dark [data-page="policies"] .text-slate-700,
+.dark [data-page="policies"] .text-gray-600,
+.dark [data-page="policies"] .text-gray-700,
+.dark [data-page="policies"] [class*="text-[var(--secondary-foreground)]"] {
+  color: var(--policies-neutral-text);
+}
+
+.dark [data-page="policies"] .border-slate-200,
+.dark [data-page="policies"] .border-slate-300,
+.dark [data-page="policies"] .border-gray-200,
+.dark [data-page="policies"] .border-gray-300,
+.dark [data-page="policies"] .border-gray-400,
+.dark [data-page="policies"] .border-gray-500,
+.dark [data-page="policies"] [class*="border-[var(--border)]"],
+.dark [data-page="policies"] article.border-gray-500 {
+  border-color: var(--policies-neutral-border);
+}
+
+.dark [data-page="policies"] article.hover\:border-gray-600:hover {
+  border-color: var(--policies-neutral-border);
+}
+
+.dark [data-page="policies"] .text-\[var\(--muted-foreground\)\] {
+  color: var(--policies-text-muted);
+}
+
+.dark [data-page="policies"] .text-\[var\(--foreground\)\] {
+  color: var(--policies-text-primary);
+}
+
+.dark [data-page="policies"] .hover\:border-\[var\(--accent\)\]:hover {
+  border-color: var(--policies-blue-border);
+}
+
+.dark [data-page="policies"] .hover\:bg-\[var\(--muted\)\]:hover,
+.dark [data-page="policies"] .hover\:bg-blue-50:hover,
+.dark [data-page="policies"] .hover\:bg-gray-50:hover {
+  background-color: var(--policies-card-bg-hover);
+}
+
+.dark [data-page="policies"] .hover\:text-\[var\(--accent\)\]:hover {
+  color: var(--policies-blue-text);
+}
+
+.dark [data-policy-card] {
+  background:
+    linear-gradient(0deg, rgba(148, 163, 184, 0.08), rgba(148, 163, 184, 0.08)),
+    var(--policy-card-surface);
+  border-color: rgba(148, 163, 184, 0.24);
+}
+
+.dark [data-policy-card][data-policy-status="open"] {
+  background:
+    linear-gradient(0deg, var(--policy-card-open-tint), var(--policy-card-open-tint)),
+    var(--policy-card-surface);
+  border-color: var(--policy-card-open-border);
+}
+
+.dark [data-policy-card][data-policy-status="open"]:hover {
+  background:
+    linear-gradient(0deg, var(--policy-card-open-tint-hover), var(--policy-card-open-tint-hover)),
+    var(--policy-card-surface);
+  border-color: var(--policy-card-open-border-hover);
+}
+
+.dark [data-policy-card][data-policy-status="always"] {
+  background:
+    linear-gradient(0deg, var(--policy-card-always-tint), var(--policy-card-always-tint)),
+    var(--policy-card-surface);
+  border-color: var(--policy-card-always-border);
+}
+
+.dark [data-policy-card][data-policy-status="always"]:hover {
+  background:
+    linear-gradient(0deg, var(--policy-card-always-tint-hover), var(--policy-card-always-tint-hover)),
+    var(--policy-card-surface);
+  border-color: var(--policy-card-always-border-hover);
+}
+
+.dark [data-policy-card][data-policy-status="check"] {
+  background:
+    linear-gradient(0deg, var(--policy-card-check-tint), var(--policy-card-check-tint)),
+    var(--policy-card-surface);
+  border-color: var(--policy-card-check-border);
+}
+
+.dark [data-policy-card][data-policy-status="check"]:hover {
+  background:
+    linear-gradient(0deg, var(--policy-card-check-tint-hover), var(--policy-card-check-tint-hover)),
+    var(--policy-card-surface);
+  border-color: var(--policy-card-check-border-hover);
+}
+
+.dark [data-policy-card][data-policy-status="unknown"] {
+  background:
+    linear-gradient(0deg, var(--policy-card-unknown-tint), var(--policy-card-unknown-tint)),
+    var(--policy-card-surface);
+  border-color: var(--policy-card-unknown-border);
+}
+
+.dark [data-policy-card][data-policy-status="unknown"]:hover {
+  background:
+    linear-gradient(0deg, var(--policy-card-unknown-tint-hover), var(--policy-card-unknown-tint-hover)),
+    var(--policy-card-surface);
+  border-color: var(--policy-card-unknown-border-hover);
+}
+
+.dark [data-policy-card][data-policy-status="closed"] {
+  background:
+    linear-gradient(0deg, var(--policy-card-closed-tint), var(--policy-card-closed-tint)),
+    var(--policy-card-surface);
+  border-color: var(--policy-card-closed-border);
+}
+
+.dark [data-policy-card][data-policy-status="closed"]:hover {
+  background:
+    linear-gradient(0deg, var(--policy-card-closed-tint-hover), var(--policy-card-closed-tint-hover)),
+    var(--policy-card-surface);
+  border-color: var(--policy-card-closed-border-hover);
+}
+
+.dark [data-policy-card][data-policy-urgent="true"] {
+  border-color: rgba(248, 113, 113, 0.44);
+}
+
+.dark [data-policy-card][data-policy-urgent="true"]:hover {
+  border-color: rgba(248, 113, 113, 0.54);
+}
+
+.dark [data-policy-card]:hover {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.025),
+    0 14px 34px rgba(0, 0, 0, 0.20);
+}
+
+.dark [data-policy-card]:hover h3 {
+  color: var(--text-primary);
+}
+
+.dark [data-policy-card] .policy-status-badge {
+  box-shadow: inset 0 0 0 1px rgba(248, 250, 252, 0.16);
+}
+
+.dark [data-policy-card] .policy-status-badge.status-open {
+  background-color: #10B981;
+  color: #ECFDF5;
+  box-shadow: inset 0 0 0 1px rgba(110, 231, 183, 0.36);
+}
+
+.dark [data-policy-card] .policy-status-badge.status-always {
+  background-color: #3B82F6;
+  color: #EFF6FF;
+  box-shadow: inset 0 0 0 1px rgba(147, 197, 253, 0.36);
+}
+
+.dark [data-policy-card] .policy-status-badge.status-check {
+  background-color: #14B8A6;
+  color: #F0FDFA;
+  box-shadow: inset 0 0 0 1px rgba(94, 234, 212, 0.36);
+}
+
+.dark [data-policy-card] .policy-status-badge.status-unknown {
+  background-color: #D97706;
+  color: #FFFBEB;
+  box-shadow: inset 0 0 0 1px rgba(252, 211, 77, 0.38);
+}
+
+.dark [data-policy-card] .policy-status-badge.status-closed {
+  background-color: #475569;
+  color: #F8FAFC;
+  box-shadow: inset 0 0 0 1px rgba(203, 213, 225, 0.28);
 }
 
 /* Blob animation */
 @keyframes blob {
-  0% {
-    transform: translate(0px, 0px) scale(1);
-  }
-  33% {
-    transform: translate(30px, -50px) scale(1.1);
-  }
-  66% {
-    transform: translate(-20px, 20px) scale(0.9);
-  }
-  100% {
-    transform: translate(0px, 0px) scale(1);
-  }
+  0%   { transform: translate(0px, 0px) scale(1); }
+  33%  { transform: translate(30px, -50px) scale(1.1); }
+  66%  { transform: translate(-20px, 20px) scale(0.9); }
+  100% { transform: translate(0px, 0px) scale(1); }
 }
 
-.animate-blob {
-  animation: blob 7s infinite;
-}
+.animate-blob { animation: blob 7s infinite; }
+.animation-delay-2000 { animation-delay: 2s; }
+.animation-delay-4000 { animation-delay: 4s; }
 
-.animation-delay-2000 {
-  animation-delay: 2s;
-}
-
-.animation-delay-4000 {
-  animation-delay: 4s;
-}
-
-/* Shimmer animation for progress bar */
 @keyframes shimmer {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(100%);
-  }
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
 }
 
-.animate-shimmer {
-  animation: shimmer 2s infinite;
-}
+.animate-shimmer { animation: shimmer 2s infinite; }


### PR DESCRIPTION
## Summary
- 정책/맞춤정책 카테고리 다중 선택 시 프론트에서 카테고리별 요청을 나눠 보내고 결과를 중복 제거해 합치도록 수정했습니다.
- 프로필 수정, 맞춤정책, 계정 설정 흐름을 실제 인증/프로필 API와 연결하고 stale auth 세션은 로그인으로 정리되도록 보강했습니다.
- 이메일 인증 완료/재발송 UX, 비밀번호 변경, 회원탈퇴, OAuth 계정 처리와 관련된 프론트 상태 처리를 정리했습니다.
- 주요 정책/계정 화면과 공통 컴포넌트에 다크모드 및 반응형 UI 보정을 적용했습니다.

## Backend Scope
- 백엔드 파일 변경 없음.
- PR 브랜치는 `origin/dev` 기준으로 만들었고, `origin/dev..HEAD` diff에서 `backend/` 변경이 없는 것을 확인했습니다.

## Validation
- `npm run build` in `frontend` passed.
- Commit diff contains only `frontend/` files.